### PR TITLE
add --cores flag to multicore makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,32 @@
+CORES=2
 all: BCnS_ALG UnicellLG UnicellLGOrthofinder BCnSSimakov2022
 
 BCnS_ALG: LG_db/BCnS_LGs.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf BCnS_LGs.tar.gz; \
 	cd BCnS_LGs; \
-	snakemake
+	snakemake --cores $(CORES)
 
 BCnSSimakov2022: LG_db/BCnSSimakov2022.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf BCnSSimakov2022.tar.gz; \
 	cd BCnSSimakov2022; \
-	snakemake
+	snakemake --cores $(CORES)
 
 UnicellLG: LG_db/UnicellMetazoanLgs.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf UnicellMetazoanLgs.tar.gz; \
 	cd UnicellMetazoanLgs; \
-	snakemake
+	snakemake --cores $(CORES)
 
 UnicellLGOrthofinder: LG_db/UnicellMetazoanLgsOrthofinder.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf UnicellMetazoanLgsOrthofinder.tar.gz; \
 	cd UnicellMetazoanLgsOrthofinder; \
-	snakemake
+	snakemake --cores $(CORES)
 
 CLG_v1.0: LG_db/CLG_v1.0.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf CLG_v1.0.tar.gz; \
 	cd CLG_v1.0; \
-	snakemake
+	snakemake --cores $(CORES)


### PR DESCRIPTION
Hi Darrin,

I have noticed that, on multicore systems, the default `Makefile` doesn't have a `--cores` flag, which causes compilation to fail. This small change fixed it for me. I guess there's better ways to do this, e.g. to autodetect the number of cores, but I'm not very familiar with snakemake and the such.

Cheers,

Xavi