### PR TITLE
Validate non-empty input files in filechecker

### DIFF
--- a/scripts/odp_filechecker
+++ b/scripts/odp_filechecker
@@ -23,6 +23,7 @@ Usage instructions:
 # This block imports fasta-parser as fasta
 import os
 import sys
+import itertools
 snakefile_path = os.path.dirname(os.path.realpath(workflow.snakefile))
 dependencies_path = os.path.join(snakefile_path, "../dependencies/fasta-parser")
 sys.path.insert(1, dependencies_path)
@@ -101,11 +102,16 @@ def check_genome_file_legality(fastapath):
     3. Check that each sequence contains only valid DNA characters.
     """
     odpf.check_file_exists(fastapath)
+    genome_iter = fasta.parse(fastapath)
+    try:
+        first_record = next(genome_iter)
+    except StopIteration:
+        raise IOError(f"The genome fasta file has no records: {fastapath}")
     genome_headers = set()
     duplicates = set()
     illegal_sequences = {}
     allowed = set("ACGTNRYKMSWBDHV")
-    for record in fasta.parse(fastapath):
+    for record in itertools.chain([first_record], genome_iter):
         seq = str(record.seq).upper()
         if record.id not in genome_headers:
             genome_headers.add(record.id)
@@ -162,13 +168,18 @@ def check_protein_file_legality(peppath, duplicate_handling="fail"):
     4. Check that each sequence contains only valid amino-acid characters.
     """
     odpf.check_file_exists(peppath)
+    protein_iter = fasta.parse(peppath)
+    try:
+        first_record = next(protein_iter)
+    except StopIteration:
+        raise IOError(f"The protein fasta file has no records: {peppath}")
     protein_headers = set()
     duplicate_headers = set()
     sequence_hashes = set()
     duplicate_sequences = set()
     illegal_sequences = {}
     allowed = set("ACDEFGHIKLMNPQRSTVWYBXZJUO*")
-    for record in fasta.parse(peppath):
+    for record in itertools.chain([first_record], protein_iter):
         seq = str(record.seq).upper()
         if record.id not in protein_headers:
             protein_headers.add(record.id)
@@ -248,6 +259,7 @@ def check_chrom_file_legality(chrompath, fastapath, peppath):
     2. Check that the proteins seen in column 1 were seen in the protein fasta file.
     3. Check that the scaffolds were seen in the genome assembly fasta file.
     """
+    odpf.check_file_exists(chrompath)
     if not odpf.chrom_file_is_legal(chrompath):
         raise IOError("The chrom file is not legal: {}".format(chrompath))
 
@@ -257,9 +269,11 @@ def check_chrom_file_legality(chrompath, fastapath, peppath):
     proteins_not_in_pep = set()
     scaffolds_not_in_fasta = set()
     with open(chrompath, 'r') as chromhandle:
+        has_line = False
         for line in chromhandle:
             line = line.strip()
             if line:
+                has_line = True
                 fields = line.split("\t")
                 protid = fields[0]
                 scaffold = fields[1]
@@ -267,6 +281,8 @@ def check_chrom_file_legality(chrompath, fastapath, peppath):
                     proteins_not_in_pep.add(protid)
                 if scaffold not in genome_headers:
                     scaffolds_not_in_fasta.add(scaffold)
+    if not has_line:
+        raise IOError(f"The chrom file has no lines: {chrompath}")
 
     if len(proteins_not_in_pep) > 0:
         dupstring = "".join(["*    - " + str(x) + "\n" for x in sorted(proteins_not_in_pep)[:3]])

--- a/unittesting/test_sequence_legality.py
+++ b/unittesting/test_sequence_legality.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 import pytest
 import hashlib
+import itertools
 
 # set up paths to import dependencies
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +20,10 @@ class _ODPFunctions:
         if not Path(path).is_file():
             raise IOError(f"File does not exist: {path}")
 
+    @staticmethod
+    def chrom_file_is_legal(path):
+        return True
+
 odpf = _ODPFunctions()
 
 # extract function definitions from Snakemake file
@@ -32,12 +37,15 @@ def _load_func(name):
         'fasta': fasta,
         'odpf': odpf,
         'hashlib': hashlib,
+        'os': os,
+        'itertools': itertools,
     }
     exec(code, namespace)
     return namespace[name]
 
 check_genome_file_legality = _load_func('check_genome_file_legality')
 check_protein_file_legality = _load_func('check_protein_file_legality')
+check_chrom_file_legality = _load_func('check_chrom_file_legality')
 
 
 def write_fasta(tmp_path, text):
@@ -62,3 +70,26 @@ def test_protein_illegal_chars(tmp_path):
     )
     with pytest.raises(IOError):
         check_protein_file_legality(fasta_path)
+
+
+def test_genome_empty(tmp_path):
+    fasta_path = write_fasta(tmp_path, "")
+    with pytest.raises(IOError):
+        check_genome_file_legality(fasta_path)
+
+
+def test_protein_empty(tmp_path):
+    fasta_path = write_fasta(tmp_path, "")
+    with pytest.raises(IOError):
+        check_protein_file_legality(fasta_path)
+
+
+def test_chrom_empty(tmp_path):
+    genome_path = tmp_path / "genome.fasta"
+    genome_path.write_text(">s1\nACGT\n")
+    protein_path = tmp_path / "protein.fasta"
+    protein_path.write_text(">p1\nM\n")
+    chrom_path = tmp_path / "test.chrom"
+    chrom_path.write_text("")
+    with pytest.raises(IOError):
+        check_chrom_file_legality(str(chrom_path), str(genome_path), str(protein_path))


### PR DESCRIPTION
## Summary
- parse genome and protein FASTA files to ensure they contain records using the fasta parser
- flag chrom files with no content by checking for at least one line
- update unit tests for parser-based empty checks
