### PR TITLE
Port forward PRs #43 and #59 onto main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CFLAGS   ?= -O3 -std=c11 -Wall -Wextra
 CPPFLAGS ?= -Ibin/seqtk
 LDLIBS   ?= -lz
 
+# CORES used by snakemake for LG_db builds. Override: `make CORES=8`.
+CORES    ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+
 
 all: BCnS_ALG UnicellLG UnicellLGOrthofinder BCnSSimakov2022 seqtk fainfo
 
@@ -38,28 +41,28 @@ BCnS_ALG: LG_db/BCnS_LGs.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf BCnS_LGs.tar.gz; \
 	cd BCnS_LGs; \
-	snakemake
+	snakemake --cores $(CORES)
 
 BCnSSimakov2022: LG_db/BCnSSimakov2022.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf BCnSSimakov2022.tar.gz; \
 	cd BCnSSimakov2022; \
-	snakemake
+	snakemake --cores $(CORES)
 
 UnicellLG: LG_db/UnicellMetazoanLgs.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf UnicellMetazoanLgs.tar.gz; \
 	cd UnicellMetazoanLgs; \
-	snakemake
+	snakemake --cores $(CORES)
 
 UnicellLGOrthofinder: LG_db/UnicellMetazoanLgsOrthofinder.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf UnicellMetazoanLgsOrthofinder.tar.gz; \
 	cd UnicellMetazoanLgsOrthofinder; \
-	snakemake
+	snakemake --cores $(CORES)
 
 CLG_v1.0: LG_db/CLG_v1.0.tar.gz
 	cd LG_db; \
 	tar --skip-old-files -xzvf CLG_v1.0.tar.gz; \
 	cd CLG_v1.0; \
-	snakemake
+	snakemake --cores $(CORES)

--- a/scripts/odp_nway_rbh
+++ b/scripts/odp_nway_rbh
@@ -48,6 +48,7 @@ import odp_functions as odpf
 
 # we need a way to handle the colors
 from odp_color_manager import generate_random_color as grc
+from odp_color_manager import yield_color
 
 configfile: "config.yaml"
 
@@ -630,9 +631,14 @@ rule groupby_rbh_results:
         # We should automatically assign some colors to the groups
         # This feature was part of some requests from Grisha Zolotarov
         # - request documented here: https://github.com/conchoecia/odp/issues/31
-        # Generate a random color for each row by running the grc() command once per row.
-        #  If alpha of the same row is greater than 0.05, then leave the color black
-        grouped_multiple["color"] = grouped_multiple.apply(lambda x: grc()
+        # Sequential palette gives stable, repeatable colors across runs;
+        # falls back to random if config["random_colors"] is truthy.
+        if config.get("random_colors", False):
+            color_fn = grc
+        else:
+            yc = yield_color(config.get("color_palette", "mypals25"))
+            color_fn = lambda: next(yc)
+        grouped_multiple["color"] = grouped_multiple.apply(lambda x: color_fn()
                     if x["alpha"] <= 0.05 else "#000000", axis = 1)
         # move the color column to right after the gene_group column
         cols1 = ['rbh', 'gene_group', 'color', 'count', 'alpha', 'alpha_type']

--- a/source/odp_color_manager.py
+++ b/source/odp_color_manager.py
@@ -358,6 +358,34 @@ def generate_random_color():
             if saturation > 0.3 and saturation < 0.8:
                 return "#{:06x}".format(color)
 
+# Default sequential palettes used by yield_color(). mypals25 is a
+# 25-color qualitative palette; mytableau20 mirrors Tableau 20.
+_YIELD_COLOR_PALETTES = {
+    "mypals25": [
+        "#1F78C8", "#DD0000", "#33a02c", "#6A33C2", "#ff7f00",
+        "#565656", "#EEC600", "#a6cee3", "#FB6496", "#b2df8a",
+        "#CAB2D6", "#FDBF6F", "#999999", "#EEE685", "#C8308C",
+        "#FF83FA", "#C814FA", "#0000DD", "#36648B", "#00E2E5",
+        "#00FF00", "#778B00", "#BEBE00", "#8B3B00", "#A52A3C",
+    ],
+    "tableau20": [
+        "#1F77B4", "#AEC7E8", "#FF7F0E", "#FFBB78", "#2CA02C", "#98DF8A",
+        "#D62728", "#FF9896", "#9467BD", "#C5B0D5", "#8C564B", "#C49C94",
+        "#E377C2", "#F7B6D2", "#7F7F7F", "#C7C7C7", "#BCBD22", "#DBDB8D",
+        "#17BECF", "#9EDAE5",
+    ],
+}
+
+def yield_color(palette="mypals25"):
+    """Generator yielding colors from a fixed qualitative palette, looping
+    indefinitely. Used where deterministic, repeatable color assignment is
+    preferred over generate_random_color()."""
+    pal = _YIELD_COLOR_PALETTES[palette]
+    i = 0
+    while True:
+        yield pal[i % len(pal)]
+        i += 1
+
 def calculate_brightness(color):
     red = (color >> 16) & 0xFF
     green = (color >> 8) & 0xFF


### PR DESCRIPTION
Lands two commits that were pushed to `decay-branch` after PR #110 was merged, so they didn't make it into `main`.

- 8bf0fdc — `Makefile`: add `CORES` var auto-detected via `nproc`/`sysctl` (override with `make CORES=8`). Wires `--cores $(CORES)` into all five `snakemake` invocations. Co-authored with @xgrau (closes #59).
- 9a86162 — `nway_rbh`: add `yield_color()` generator to `source/odp_color_manager.py` (palettes `mypals25` default, `tableau20`). Sequential palette is the new default in `groupby_rbh_results`; original random behavior preserved via `config["random_colors"]: true`, palette selectable via `config["color_palette"]`. Co-authored with @beroe (closes #43).