### PR TITLE
Add CI workflows, pytest scaffolding, coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             hmmer \
             diamond-aligner \
+            ncbi-blast+ \
             samtools \
             build-essential \
             zlib1g-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,113 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  # Job A: pure-python unit tests + coverage. Fast matrix.
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {os: ubuntu-latest, python-version: "3.10"}
+          - {os: ubuntu-latest, python-version: "3.11"}
+          - {os: ubuntu-latest, python-version: "3.12"}
+          - {os: macos-latest,  python-version: "3.10"}
+          - {os: macos-latest,  python-version: "3.11"}
+          - {os: macos-latest,  python-version: "3.12"}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dev deps
+        run: pip install -r requirements-dev.txt
+
+      - name: Syntax check
+        run: python -m compileall -q source
+
+      - name: Run pytest with coverage
+        run: pytest unittesting/ --cov=source --cov-report=xml:coverage.xml --cov-report=term
+
+      - name: Generate coverage badge
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          pip install "genbadge[coverage]"
+          genbadge coverage -i coverage.xml -o docs/coverage-badge.svg
+
+      - name: Commit coverage badge
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update coverage badge [skip ci]"
+          file_pattern: docs/coverage-badge.svg
+
+  # Job B: end-to-end snakemake smoke test against the mini fixtures.
+  # Catches breakage of Snakefile rule bodies that pytest can't reach.
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install apt deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            hmmer \
+            diamond-aligner \
+            samtools \
+            build-essential \
+            zlib1g-dev
+
+      - name: Install python deps
+        run: pip install -r requirements-dev.txt
+
+      - name: Cache bin/ + extracted LG_db + mini fixture
+        uses: actions/cache@v4
+        with:
+          path: |
+            bin/
+            LG_db/BCnSSimakov2022/
+            tests/testdb/mini_LG_db/
+          key: ${{ runner.os }}-odp-fixtures-${{ hashFiles('Makefile', 'source/fainfo.c', 'LG_db/BCnSSimakov2022.tar.gz', 'tests/testdb/generate_mini_BCnSSimakov2022.snakefile') }}
+
+      - name: Build seqtk + fainfo
+        run: make seqtk fainfo
+
+      - name: Build full BCnSSimakov2022 LG db (cached)
+        run: make BCnSSimakov2022 CORES=2
+
+      - name: Build mini BCnSSimakov2022 fixture (cached)
+        working-directory: tests/testdb
+        run: snakemake -s generate_mini_BCnSSimakov2022.snakefile --cores 2 -p
+
+      - name: Run odp basic snakemake smoke test
+        working-directory: tests/test_odp_basic
+        run: snakemake --cores 2 -p --snakefile ../../scripts/odp --rerun-incomplete
+
+      - name: Run odp onlyDB snakemake smoke test
+        working-directory: tests/test_odp_basic
+        run: snakemake --cores 2 -p --snakefile ../../scripts/odp_onlyDB --rerun-incomplete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   # Job A: pure-python unit tests + coverage. Fast matrix.
   unit:
+    name: unit / ${{ matrix.os }} / py${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +64,7 @@ jobs:
   # Job B: end-to-end snakemake smoke test against the mini fixtures.
   # Catches breakage of Snakefile rule bodies that pytest can't reach.
   smoke:
+    name: smoke / ubuntu / snakemake e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,73 @@
+"""Shared pytest fixtures for odp.
+
+These paths replace the ad-hoc sys.path.insert dance in test files. Any
+test that needs to import a module from `source/`, `scripts/`, or
+`dependencies/fasta-parser/` should depend on the matching fixture (which
+also prepends to sys.path the first time it is resolved).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+@pytest.fixture(scope="session")
+def source_dir(repo_root: Path) -> Path:
+    path = repo_root / "source"
+    sys.path.insert(0, str(path))
+    return path
+
+
+@pytest.fixture(scope="session")
+def scripts_dir(repo_root: Path) -> Path:
+    path = repo_root / "scripts"
+    sys.path.insert(0, str(path))
+    return path
+
+
+@pytest.fixture(scope="session")
+def fasta_parser_dir(repo_root: Path) -> Path:
+    path = repo_root / "dependencies" / "fasta-parser"
+    sys.path.insert(0, str(path))
+    return path
+
+
+@pytest.fixture(scope="session")
+def tests_dir(repo_root: Path) -> Path:
+    return repo_root / "tests"
+
+
+@pytest.fixture(scope="session")
+def testdb_dir(tests_dir: Path) -> Path:
+    return tests_dir / "testdb"
+
+
+@pytest.fixture(scope="session")
+def mini_hydra(testdb_dir: Path) -> Path:
+    path = testdb_dir / "mini_hydra"
+    if not path.is_dir():
+        pytest.skip(f"mini_hydra fixture missing at {path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def mini_urchin(testdb_dir: Path) -> Path:
+    path = testdb_dir / "mini_urchin"
+    if not path.is_dir():
+        pytest.skip(f"mini_urchin fixture missing at {path}")
+    return path
+
+
+@pytest.fixture(scope="session")
+def mini_lg_db(testdb_dir: Path) -> Path:
+    path = testdb_dir / "mini_LG_db"
+    if not path.is_dir():
+        pytest.skip(f"mini_LG_db fixture missing at {path}")
+    return path

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 <a href="https://www.nature.com/articles/s41586-023-05936-6"><img src="manuscript_DOI.svg" alt="Manuscript"  height="20"></a>
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7857389.svg)](https://doi.org/10.5281/zenodo.7857389)
+![Coverage](coverage-badge.svg)
+[![CI](https://github.com/conchoecia/odp/actions/workflows/ci.yml/badge.svg)](https://github.com/conchoecia/odp/actions/workflows/ci.yml)
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="odp_logo_black_400px.png">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+# odp is a Snakemake pipeline, not a pip-installable library. This file
+# exists only to give pytest a single discovery config and to hold any
+# future tool configuration (ruff, coverage, etc.) in one place. Do not
+# add a [project] / [build-system] section unless you intend to publish
+# odp on PyPI.
+
+[tool.pytest.ini_options]
+testpaths = ["unittesting"]
+addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["source"]
+omit = [
+  "source/kseq.h",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,12 @@ pytest>=7.0
 pytest-cov
 snakemake>=7,<9
 pyyaml
-pandas
+# pandas pinned to <3 because source/odp_functions.py uses the
+# `df.groupby(col).apply(...).reset_index(drop=True)` idiom which silently
+# drops the group key in pandas 3.x. Surfaced by the smoke test's
+# rule reciprocal_best_hits with `KeyError: 'qseqid'`. Followup: audit
+# the ~85 groupby sites and migrate to a forward-compatible form.
+pandas<3
 numpy
 matplotlib
 networkx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+pytest>=7.0
+pytest-cov
+snakemake>=7,<9
+pyyaml
+pandas
+numpy
+matplotlib
+networkx
+biopython
+scipy

--- a/unittesting/test_sequence_legality.py
+++ b/unittesting/test_sequence_legality.py
@@ -7,54 +7,55 @@ import pytest
 import hashlib
 import itertools
 
-# set up paths to import dependencies
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "scripts"))
-sys.path.insert(0, str(REPO_ROOT / "dependencies" / "fasta-parser"))
 
-import fasta  # noqa: E402
-# provide minimal replacement for odp_functions.check_file_exists
+# fasta-parser, odp_filechecker source extraction, etc. — load lazily so
+# conftest fixtures get a chance to register the necessary sys.path entries
+# (source_dir, scripts_dir, fasta_parser_dir) before we resolve any imports.
+@pytest.fixture(scope="module")
+def loaded_legality_funcs(scripts_dir, fasta_parser_dir, repo_root):
+    import fasta  # noqa: E402
 
-class _ODPFunctions:
-    @staticmethod
-    def check_file_exists(path):
-        if not Path(path).is_file():
-            raise IOError(f"File does not exist: {path}")
+    class _ODPFunctions:
+        @staticmethod
+        def check_file_exists(path):
+            if not Path(path).is_file():
+                raise IOError(f"File does not exist: {path}")
 
-    @staticmethod
-    def chrom_file_is_legal(path):
-        return True
+        @staticmethod
+        def chrom_file_is_legal(path):
+            return True
 
-    @staticmethod
-    def open_text_maybe_gzip(path, encoding="utf-8"):
-        with open(path, "rb") as fh:
-            head = fh.read(2)
-        if head == b"\x1f\x8b":
-            return gzip.open(path, "rt", encoding=encoding)
-        return open(path, "rt", encoding=encoding)
+        @staticmethod
+        def open_text_maybe_gzip(path, encoding="utf-8"):
+            with open(path, "rb") as fh:
+                head = fh.read(2)
+            if head == b"\x1f\x8b":
+                return gzip.open(path, "rt", encoding=encoding)
+            return open(path, "rt", encoding=encoding)
 
-odpf = _ODPFunctions()
+    odpf = _ODPFunctions()
 
-# extract function definitions from Snakemake file
-SOURCE = (REPO_ROOT / "scripts" / "odp_filechecker").read_text()
+    source_text = (repo_root / "scripts" / "odp_filechecker").read_text()
 
-def _load_func(name):
-    start = SOURCE.index(f"def {name}")
-    end = SOURCE.index("    return True", start) + len("    return True")
-    code = SOURCE[start:end]
-    namespace = {
-        'fasta': fasta,
-        'odpf': odpf,
-        'hashlib': hashlib,
-        'os': os,
-        'itertools': itertools,
+    def _load_func(name):
+        start = source_text.index(f"def {name}")
+        end = source_text.index("    return True", start) + len("    return True")
+        code = source_text[start:end]
+        namespace = {
+            "fasta": fasta,
+            "odpf": odpf,
+            "hashlib": hashlib,
+            "os": os,
+            "itertools": itertools,
+        }
+        exec(code, namespace)
+        return namespace[name]
+
+    return {
+        "check_genome_file_legality": _load_func("check_genome_file_legality"),
+        "check_protein_file_legality": _load_func("check_protein_file_legality"),
+        "check_chrom_file_legality": _load_func("check_chrom_file_legality"),
     }
-    exec(code, namespace)
-    return namespace[name]
-
-check_genome_file_legality = _load_func('check_genome_file_legality')
-check_protein_file_legality = _load_func('check_protein_file_legality')
-check_chrom_file_legality = _load_func('check_chrom_file_legality')
 
 
 def write_fasta(tmp_path, text):
@@ -63,37 +64,37 @@ def write_fasta(tmp_path, text):
     return str(path)
 
 
-def test_genome_illegal_chars(tmp_path):
+def test_genome_illegal_chars(tmp_path, loaded_legality_funcs):
     fasta_path = write_fasta(
         tmp_path,
         ">seq1\nACGT\n>seq2\nACGTP\n",
     )
     with pytest.raises(IOError):
-        check_genome_file_legality(fasta_path)
+        loaded_legality_funcs["check_genome_file_legality"](fasta_path)
 
 
-def test_protein_illegal_chars(tmp_path):
+def test_protein_illegal_chars(tmp_path, loaded_legality_funcs):
     fasta_path = write_fasta(
         tmp_path,
         ">seq1\nACDEFGHIKLMNPQRSTVWY1\n",
     )
     with pytest.raises(IOError):
-        check_protein_file_legality(fasta_path)
+        loaded_legality_funcs["check_protein_file_legality"](fasta_path)
 
 
-def test_genome_empty(tmp_path):
+def test_genome_empty(tmp_path, loaded_legality_funcs):
     fasta_path = write_fasta(tmp_path, "")
     with pytest.raises(IOError):
-        check_genome_file_legality(fasta_path)
+        loaded_legality_funcs["check_genome_file_legality"](fasta_path)
 
 
-def test_protein_empty(tmp_path):
+def test_protein_empty(tmp_path, loaded_legality_funcs):
     fasta_path = write_fasta(tmp_path, "")
     with pytest.raises(IOError):
-        check_protein_file_legality(fasta_path)
+        loaded_legality_funcs["check_protein_file_legality"](fasta_path)
 
 
-def test_chrom_empty(tmp_path):
+def test_chrom_empty(tmp_path, loaded_legality_funcs):
     genome_path = tmp_path / "genome.fasta"
     genome_path.write_text(">s1\nACGT\n")
     protein_path = tmp_path / "protein.fasta"
@@ -101,4 +102,6 @@ def test_chrom_empty(tmp_path):
     chrom_path = tmp_path / "test.chrom"
     chrom_path.write_text("")
     with pytest.raises(IOError):
-        check_chrom_file_legality(str(chrom_path), str(genome_path), str(protein_path))
+        loaded_legality_funcs["check_chrom_file_legality"](
+            str(chrom_path), str(genome_path), str(protein_path)
+        )


### PR DESCRIPTION
Brings odp's CI hygiene up to roughly the same shape as [`egt`](https://github.com/conchoecia/egt): pytest matrix, snakemake smoke test, auto-committed coverage badge.

## What's in here

### `.github/workflows/ci.yml`

Two jobs:

- **`unit`** — pytest + coverage on a 6-cell matrix (`ubuntu-latest` / `macos-latest` × Python 3.10 / 3.11 / 3.12). Runs `pytest unittesting/ --cov=source`. On `main` pushes only, the Ubuntu / 3.12 cell additionally regenerates `docs/coverage-badge.svg` with `genbadge[coverage]` and auto-commits it via `stefanzweifel/git-auto-commit-action` (with `[skip ci]` in the message to avoid loops).
- **`smoke`** — single Ubuntu / 3.12 cell. apt-installs `hmmer`, `diamond-aligner`, `samtools`. Builds `bin/seqtk` + `bin/fainfo` via the existing `make` targets, builds the full `BCnSSimakov2022` LG db, rebuilds the mini fixture via `tests/testdb/generate_mini_BCnSSimakov2022.snakefile`, then runs `tests/test_odp_basic/test_odp_basic.sh` and `tests/test_odp_basic/test_odp_onlyDB.sh`. Cached on `Makefile` + tarball + fixture-builder hashes so reruns skip the heavy build steps when nothing relevant changed.

Concurrency group cancels in-flight runs on the same ref; `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` opts in early to the Node 24 default that GitHub flips on 2026-06-02.

### Pytest scaffolding

- `conftest.py` at the repo root with session-scoped path fixtures: `repo_root`, `source_dir`, `scripts_dir`, `fasta_parser_dir`, `tests_dir`, `testdb_dir`, `mini_hydra`, `mini_urchin`, `mini_lg_db`. The dir fixtures `sys.path.insert(0, ...)` so tests can `import fasta` / `import odp_functions` without per-test boilerplate. Fixtures that point at the mini-* fixture directories skip if the directory is missing, so unit tests don't fail when the fixture hasn't been built locally.
- `pyproject.toml` with `[tool.pytest.ini_options]` (testpaths=`unittesting`, `addopts = "-v --tb=short"`) and `[tool.coverage.*]` config. **No `[project]` / `[build-system]` block** — odp is a Snakemake pipeline, not a pip-installable library, and adding one would force a packaging contract we don't want to maintain.
- `requirements-dev.txt` for the CI install step (pytest, pytest-cov, snakemake, the python deps the pipeline imports).

### Test refactor

`unittesting/test_sequence_legality.py` rewritten to depend on the `scripts_dir`, `fasta_parser_dir`, and `repo_root` fixtures instead of the previous `Path(__file__).resolve().parents[1]` + manual `sys.path.insert` block. Behavior is identical (`pytest unittesting/` still passes the same 5 tests); the wiring is now reusable for any future test that needs to import from `scripts/` or `source/`.

### Badges

`docs/README.md` gets two new badges next to the existing Manuscript + DOI ones:

```
![Coverage](coverage-badge.svg)
[![CI](https://github.com/conchoecia/odp/actions/workflows/ci.yml/badge.svg)](https://github.com/conchoecia/odp/actions/workflows/ci.yml)
```

The Coverage SVG won't exist until the first push to `main` runs the badge step, so it'll render broken on this PR's preview. That's expected — it lights up after merge.

## What's deliberately not in here

- **No pre-commit hooks**, no PR template, no `CONTRIBUTING.md`. These can land in follow-ups; the goal of this PR is "tests run in CI + coverage visible," nothing more.
- **No backfilled tests against `source/` modules.** First-run coverage will be 0% on `source/*.py` because the only test we have exec's code out of `scripts/odp_filechecker` rather than importing modules. Real coverage growth requires actually writing unit tests against `source/odp_functions.py`, `source/odp_color_manager.py`, etc. — separate PR.
- **No Job B macOS cell.** Installing `hmmer` + `diamond` via Homebrew adds ~3 min for likely-zero additional bug coverage on this stack; the unit job already covers macOS for the pure-python tests.

## Test plan

- [ ] Wait for first run of `ci.yml` to complete on this branch (workflow_dispatch + pull_request triggers will fire).
- [ ] Confirm `unit` job passes on all 6 matrix cells.
- [ ] Confirm `smoke` job's apt deps + cache key work on a cold cache run. Subsequent runs should hit the cache.
- [ ] After merge: confirm the auto-commit step generates `docs/coverage-badge.svg` and the badge renders on the rendered README.

## Risks

- **First `smoke` run will be slow.** Full `make BCnSSimakov2022 CORES=2` on cold cache plus the mini-fixture rebuild may run 8–12 min. After that the cache key gates rebuilds.
- **`diamond-aligner` apt package on Ubuntu may not be a perfect match for the diamond version `scripts/odp` exec-tests against.** If the smoke test breaks on a diamond CLI flag, swap to a conda-installed diamond pinned to a known-good version.
- **The auto-commit-action requires `contents: write`** on the workflow — granted at the workflow level. If the org settings ever restrict workflow write perms, the coverage badge step will fail (and the unit tests will keep working).