### PR TITLE
Add Orthofinder importer + external orthologs table importer

### DIFF
--- a/bin/odp
+++ b/bin/odp
@@ -303,15 +303,36 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return run_subcommand("filecheck", args)
 
 
+def _parse_name_path_args(
+    flag_name: str, entries: list[str] | None
+) -> tuple[dict, int]:
+    """Parse a list of NAME=PATH strings (the ``--bed`` / ``--chrom``
+    flag pattern). Returns ``(dict, exit_code)`` — exit_code is 0 on
+    success, 2 on a malformed entry. The dict maps NAME to PATH for
+    every successful entry."""
+    out: dict = {}
+    for entry in entries or []:
+        if "=" not in entry:
+            sys.stderr.write(
+                f"{flag_name}: expected NAME=PATH, got {entry!r}\n"
+            )
+            return out, 2
+        name, _, path = entry.partition("=")
+        out[name.strip()] = path.strip()
+    return out, 0
+
+
 def cmd_orthologs_to_rbh(args: argparse.Namespace) -> int:
-    """Join an N-column orthologs table with per-species BED files and
-    emit an odp-style `.rbh` table. The output can be fed into the
-    downstream odp subcommands (groupby, plotting, ribbon, etc.) without
-    going through the full all-vs-all diamond/blastp step.
+    """Join an N-column orthologs table with per-species coordinate files
+    (.chrom or BED) and emit an odp-style `.rbh` table. The output can be
+    fed into the downstream odp subcommands (groupby, plotting, ribbon,
+    etc.) without going through the full all-vs-all diamond/blastp step.
 
     Suitable input sources:
       * Orthofinder runs — filter `Orthogroups.tsv` to single-copy via
-        `Orthogroups_SingleCopyOrthologues.txt` first.
+        `Orthogroups_SingleCopyOrthologues.txt` first. (Or use
+        `odp orthofinder-import` to skip the filtering step and rescue
+        multi-copy OGs via synteny.)
       * Plain N-column tab-separated ortholog tables with one gene per
         species per row.
     """
@@ -321,20 +342,18 @@ def cmd_orthologs_to_rbh(args: argparse.Namespace) -> int:
     sys.path.insert(0, str(source_dir))
     import ortholog_table_importer as oti  # type: ignore
 
-    bed_paths: dict = {}
-    for entry in args.bed or []:
-        if "=" not in entry:
-            sys.stderr.write(
-                f"orthologs-to-rbh: --bed expects NAME=PATH, got {entry!r}\n"
-            )
-            return 2
-        name, _, path = entry.partition("=")
-        bed_paths[name.strip()] = path.strip()
+    chrom_paths, rc = _parse_name_path_args("orthologs-to-rbh --chrom", args.chrom)
+    if rc != 0:
+        return rc
+    bed_paths, rc = _parse_name_path_args("orthologs-to-rbh --bed", args.bed)
+    if rc != 0:
+        return rc
+    coord_paths = {**bed_paths, **chrom_paths}
 
-    if not bed_paths:
+    if not coord_paths:
         sys.stderr.write(
-            "orthologs-to-rbh: at least one --bed NAME=PATH argument is "
-            "required (one per species in the orthologs table).\n"
+            "orthologs-to-rbh: at least one --chrom or --bed NAME=PATH "
+            "argument is required (one per species in the orthologs table).\n"
         )
         return 2
 
@@ -348,7 +367,7 @@ def cmd_orthologs_to_rbh(args: argparse.Namespace) -> int:
     try:
         df = oti.orthologs_to_rbh(
             orthologs_path=args.orthologs,
-            bed_paths=bed_paths,
+            bed_paths=coord_paths,
             species_order=species_order,
             has_header=args.header,
             has_orthogroup_id_column=has_og,
@@ -363,6 +382,66 @@ def cmd_orthologs_to_rbh(args: argparse.Namespace) -> int:
     sys.stdout.write(
         f"orthologs-to-rbh: species = {[c for c in df.columns if c.endswith('_gene')]}\n"
     )
+    return 0
+
+
+def cmd_orthofinder_import(args: argparse.Namespace) -> int:
+    """Import a full Orthofinder run directory and emit an odp .rbh table.
+
+    Unlike `orthologs-to-rbh` (which requires the user to pre-filter the
+    Orthofinder output to the single-copy subset), this subcommand reads
+    Orthogroups.tsv directly and rescues multi-copy orthogroups by
+    picking the candidate gene that best fits the syntenic context
+    established by the single-copy backbone.
+    """
+    source_dir = repo_root() / "source"
+    sys.path.insert(0, str(source_dir))
+    import orthofinder_importer as ofi  # type: ignore
+    import ortholog_table_importer as oti  # type: ignore  # noqa: F401
+
+    chrom_paths, rc = _parse_name_path_args(
+        "orthofinder-import --chrom", args.chrom
+    )
+    if rc != 0:
+        return rc
+    bed_paths, rc = _parse_name_path_args(
+        "orthofinder-import --bed", args.bed
+    )
+    if rc != 0:
+        return rc
+    coord_paths = {**bed_paths, **chrom_paths}
+
+    if not coord_paths:
+        sys.stderr.write(
+            "orthofinder-import: at least one --chrom or --bed NAME=PATH "
+            "argument is required (one per species in Orthogroups.tsv).\n"
+        )
+        return 2
+
+    try:
+        rbh_df, audit = ofi.orthofinder_to_rbh(
+            orthofinder_dir=args.orthofinder_dir,
+            coord_paths=coord_paths,
+            strategy=args.multi_copy_strategy,
+            min_confidence=args.min_confidence,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        sys.stderr.write(f"orthofinder-import: {e}\n")
+        return 1
+
+    out_path = Path(args.output).resolve()
+    rbh_df.to_csv(out_path, sep="\t", index=False)
+    sys.stdout.write(
+        f"orthofinder-import: wrote {len(rbh_df)} rows to {out_path}\n"
+    )
+
+    if args.report:
+        report_path = Path(args.report).resolve()
+        n = ofi.write_audit_report(audit, report_path)
+        sys.stdout.write(
+            f"orthofinder-import: wrote {n} audit rows to {report_path}\n"
+        )
+
     return 0
 
 
@@ -444,7 +523,7 @@ SUBCOMMAND_ORDER = [
     # Pipeline:
     "run", "only-db",
     # Import paths that skip the all-vs-all RBH step:
-    "orthologs-to-rbh",
+    "orthofinder-import", "orthologs-to-rbh",
     # RBH chain:
     "nway-rbh", "rbh-to-alignments", "rbh-to-hmm", "rbh-to-ribbon",
     # Plotting:
@@ -561,24 +640,27 @@ def build_parser() -> argparse.ArgumentParser:
     def _add_orthologs_to_rbh() -> None:
         sp = sub.add_parser(
             "orthologs-to-rbh",
-            help="convert an external orthologs table + BEDs to an odp .rbh",
+            help="convert an external orthologs table + coords to an odp .rbh",
             description=(
                 "Join an N-column tab-separated orthologs table (one gene "
-                "per species per row) with per-species BED files and emit "
-                "an odp-style .rbh table. Lets users with pre-computed "
-                "orthology (e.g. an Orthofinder single-copy table) skip "
-                "the all-vs-all diamond/blastp step and feed the result "
-                "into the downstream odp pipeline."
+                "per species per row) with per-species coordinate files "
+                "(.chrom or BED, gzip-OK) and emit an odp-style .rbh "
+                "table. Lets users with pre-computed single-copy "
+                "orthology skip the all-vs-all diamond/blastp step and "
+                "feed the result into the downstream odp pipeline. For "
+                "full Orthofinder runs (including multi-copy rescue) see "
+                "`odp orthofinder-import`."
             ),
             epilog=(
                 "examples:\n"
-                "  # Orthofinder single-copy orthologs (3 species):\n"
+                "  # Orthofinder single-copy orthologs (3 species), .chrom inputs:\n"
                 "  odp orthologs-to-rbh \\\n"
                 "    --orthologs Orthogroups_SingleCopy.tsv \\\n"
-                "    --bed Bflo=Bflo.bed --bed Pech=Pech.bed --bed Pyes=Pyes.bed \\\n"
+                "    --chrom Bflo=Bflo.chrom --chrom Pech=Pech.chrom \\\n"
+                "    --chrom Pyes=Pyes.chrom \\\n"
                 "    --output rbh.tsv\n"
                 "\n"
-                "  # Plain two-column ortholog table without an orthogroup id:\n"
+                "  # Plain two-column ortholog table with BED coords:\n"
                 "  odp orthologs-to-rbh \\\n"
                 "    --orthologs my_pairs.tsv --orthogroup-id-col no \\\n"
                 "    --bed Sp1=Sp1.bed --bed Sp2=Sp2.bed \\\n"
@@ -591,11 +673,18 @@ def build_parser() -> argparse.ArgumentParser:
             help="path to the tab-separated orthologs table",
         )
         sp.add_argument(
+            "--chrom", action="append", metavar="NAME=PATH",
+            help=(
+                "odp .chrom file for one species, formatted as NAME=PATH "
+                "(gzip-OK). Repeat for each species. NAME must match a "
+                "species column in the orthologs table."
+            ),
+        )
+        sp.add_argument(
             "--bed", action="append", metavar="NAME=PATH",
             help=(
-                "BED file for one species, formatted as NAME=PATH. "
-                "Repeat for each species. NAME must match a species "
-                "column in the orthologs table (header or --species-order)."
+                "BED file for one species, formatted as NAME=PATH "
+                "(gzip-OK). Alternative to --chrom. Repeat per species."
             ),
         )
         sp.add_argument(
@@ -626,6 +715,94 @@ def build_parser() -> argparse.ArgumentParser:
         )
         sp.set_defaults(handler=cmd_orthologs_to_rbh)
 
+    def _add_orthofinder_import() -> None:
+        sp = sub.add_parser(
+            "orthofinder-import",
+            help="import a full Orthofinder run, rescuing multi-copy orthogroups",
+            description=(
+                "Read an Orthofinder run directory, partition orthogroups "
+                "into single-copy + multi-copy, and emit an odp-style .rbh "
+                "table. Multi-copy orthogroups are not discarded — the "
+                "chosen --multi-copy-strategy is used to pick the most "
+                "likely ortholog per species, optionally informed by the "
+                "syntenic context of the single-copy backbone."
+            ),
+            epilog=(
+                "examples:\n"
+                "  # Synteny-aware (default): use the single-copy backbone\n"
+                "  # to pick the best paralog per multi-copy orthogroup.\n"
+                "  odp orthofinder-import \\\n"
+                "    --orthofinder-dir Results_Apr16/ \\\n"
+                "    --chrom Bflo=Bflo.chrom --chrom Pech=Pech.chrom \\\n"
+                "    --chrom Pyes=Pyes.chrom \\\n"
+                "    --output rbh.tsv --report disambiguation.tsv\n"
+                "\n"
+                "  # Skip every multi-copy orthogroup (matches naive\n"
+                "  # filter-then-import pipelines):\n"
+                "  odp orthofinder-import \\\n"
+                "    --orthofinder-dir Results_Apr16/ --multi-copy-strategy skip \\\n"
+                "    --chrom Sp1=Sp1.chrom --chrom Sp2=Sp2.chrom \\\n"
+                "    --output rbh.tsv\n"
+            ),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        sp.add_argument(
+            "--orthofinder-dir", required=True,
+            help=(
+                "top-level Orthofinder run directory (the one containing "
+                "Orthogroups/, Single_Copy_Orthologue_Sequences/, etc.). "
+                "The Orthogroups/ subdirectory itself is also accepted."
+            ),
+        )
+        sp.add_argument(
+            "--chrom", action="append", metavar="NAME=PATH",
+            help=(
+                "odp .chrom file for one species, formatted as NAME=PATH "
+                "(gzip-OK). Repeat for each species. NAME must match a "
+                "species column in Orthogroups.tsv."
+            ),
+        )
+        sp.add_argument(
+            "--bed", action="append", metavar="NAME=PATH",
+            help="BED alternative to --chrom (gzip-OK). Repeat per species.",
+        )
+        sp.add_argument(
+            "--output", "-o", required=True,
+            help="path to write the .rbh table",
+        )
+        sp.add_argument(
+            "--multi-copy-strategy",
+            choices=["synteny", "most-common-chrom", "longest", "skip"],
+            default="synteny",
+            help=(
+                "how to choose the representative gene per species in "
+                "multi-copy orthogroups. 'synteny' (default) picks the "
+                "candidate whose chromosome and position best fit the "
+                "syntenic backbone established by single-copy "
+                "orthogroups. 'most-common-chrom' uses chromosome "
+                "voting only (no positional info). 'longest' picks the "
+                "longest CDS — fast and chromosome-blind. 'skip' drops "
+                "every multi-copy orthogroup."
+            ),
+        )
+        sp.add_argument(
+            "--min-confidence", type=float, default=1.0,
+            help=(
+                "minimum picked-candidate score required to keep a "
+                "multi-copy orthogroup. Default 1.0. Only meaningful for "
+                "'synteny' and 'most-common-chrom'."
+            ),
+        )
+        sp.add_argument(
+            "--report",
+            help=(
+                "optional path to write a per-decision audit TSV "
+                "(orthogroup, species, picked gene, score, second-best, "
+                "reason). Useful for sanity-checking the disambiguation."
+            ),
+        )
+        sp.set_defaults(handler=cmd_orthofinder_import)
+
     # Register subcommands in the user-friendly order defined above.
     for name in SUBCOMMAND_ORDER:
         if name in SNAKEFILES:
@@ -638,6 +815,8 @@ def build_parser() -> argparse.ArgumentParser:
             _add_version()
         elif name == "orthologs-to-rbh":
             _add_orthologs_to_rbh()
+        elif name == "orthofinder-import":
+            _add_orthofinder_import()
     return p
 
 
@@ -660,7 +839,10 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv[1:]
     if argv and argv[0] not in {"-h", "--help", "--version"} and not argv[0].startswith("-"):
         # All known subcommands across the parser.
-        valid = list(SNAKEFILES) + ["init", "validate", "version", "orthologs-to-rbh"]
+        valid = list(SNAKEFILES) + [
+            "init", "validate", "version", "orthologs-to-rbh",
+            "orthofinder-import",
+        ]
         if argv[0] not in valid:
             guess = _suggest(argv[0], valid)
             sys.stderr.write(f"odp: unknown subcommand {argv[0]!r}\n")

--- a/bin/odp
+++ b/bin/odp
@@ -303,6 +303,69 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return run_subcommand("filecheck", args)
 
 
+def cmd_orthologs_to_rbh(args: argparse.Namespace) -> int:
+    """Join an N-column orthologs table with per-species BED files and
+    emit an odp-style `.rbh` table. The output can be fed into the
+    downstream odp subcommands (groupby, plotting, ribbon, etc.) without
+    going through the full all-vs-all diamond/blastp step.
+
+    Suitable input sources:
+      * Orthofinder runs — filter `Orthogroups.tsv` to single-copy via
+        `Orthogroups_SingleCopyOrthologues.txt` first.
+      * Plain N-column tab-separated ortholog tables with one gene per
+        species per row.
+    """
+    # Lazy import so `odp --help` and the snakemake-backed subcommands
+    # don't pay the pandas import cost.
+    source_dir = repo_root() / "source"
+    sys.path.insert(0, str(source_dir))
+    import ortholog_table_importer as oti  # type: ignore
+
+    bed_paths: dict = {}
+    for entry in args.bed or []:
+        if "=" not in entry:
+            sys.stderr.write(
+                f"orthologs-to-rbh: --bed expects NAME=PATH, got {entry!r}\n"
+            )
+            return 2
+        name, _, path = entry.partition("=")
+        bed_paths[name.strip()] = path.strip()
+
+    if not bed_paths:
+        sys.stderr.write(
+            "orthologs-to-rbh: at least one --bed NAME=PATH argument is "
+            "required (one per species in the orthologs table).\n"
+        )
+        return 2
+
+    species_order = args.species_order.split(",") if args.species_order else None
+    has_og = (
+        True if args.orthogroup_id_col == "yes" else
+        False if args.orthogroup_id_col == "no" else
+        None
+    )
+
+    try:
+        df = oti.orthologs_to_rbh(
+            orthologs_path=args.orthologs,
+            bed_paths=bed_paths,
+            species_order=species_order,
+            has_header=args.header,
+            has_orthogroup_id_column=has_og,
+        )
+    except (ValueError, FileNotFoundError) as e:
+        sys.stderr.write(f"orthologs-to-rbh: {e}\n")
+        return 1
+
+    out_path = Path(args.output).resolve()
+    n = oti.write_rbh(df, out_path)
+    sys.stdout.write(f"orthologs-to-rbh: wrote {n} rows to {out_path}\n")
+    sys.stdout.write(
+        f"orthologs-to-rbh: species = {[c for c in df.columns if c.endswith('_gene')]}\n"
+    )
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # argparse plumbing
 # ---------------------------------------------------------------------------
@@ -380,6 +443,8 @@ def add_common_run_args(p: argparse.ArgumentParser) -> None:
 SUBCOMMAND_ORDER = [
     # Pipeline:
     "run", "only-db",
+    # Import paths that skip the all-vs-all RBH step:
+    "orthologs-to-rbh",
     # RBH chain:
     "nway-rbh", "rbh-to-alignments", "rbh-to-hmm", "rbh-to-ribbon",
     # Plotting:
@@ -493,6 +558,74 @@ def build_parser() -> argparse.ArgumentParser:
         )
         sp.set_defaults(handler=cmd_version)
 
+    def _add_orthologs_to_rbh() -> None:
+        sp = sub.add_parser(
+            "orthologs-to-rbh",
+            help="convert an external orthologs table + BEDs to an odp .rbh",
+            description=(
+                "Join an N-column tab-separated orthologs table (one gene "
+                "per species per row) with per-species BED files and emit "
+                "an odp-style .rbh table. Lets users with pre-computed "
+                "orthology (e.g. an Orthofinder single-copy table) skip "
+                "the all-vs-all diamond/blastp step and feed the result "
+                "into the downstream odp pipeline."
+            ),
+            epilog=(
+                "examples:\n"
+                "  # Orthofinder single-copy orthologs (3 species):\n"
+                "  odp orthologs-to-rbh \\\n"
+                "    --orthologs Orthogroups_SingleCopy.tsv \\\n"
+                "    --bed Bflo=Bflo.bed --bed Pech=Pech.bed --bed Pyes=Pyes.bed \\\n"
+                "    --output rbh.tsv\n"
+                "\n"
+                "  # Plain two-column ortholog table without an orthogroup id:\n"
+                "  odp orthologs-to-rbh \\\n"
+                "    --orthologs my_pairs.tsv --orthogroup-id-col no \\\n"
+                "    --bed Sp1=Sp1.bed --bed Sp2=Sp2.bed \\\n"
+                "    --output rbh.tsv\n"
+            ),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        sp.add_argument(
+            "--orthologs", "-i", required=True,
+            help="path to the tab-separated orthologs table",
+        )
+        sp.add_argument(
+            "--bed", action="append", metavar="NAME=PATH",
+            help=(
+                "BED file for one species, formatted as NAME=PATH. "
+                "Repeat for each species. NAME must match a species "
+                "column in the orthologs table (header or --species-order)."
+            ),
+        )
+        sp.add_argument(
+            "--output", "-o", required=True,
+            help="path to write the .rbh table",
+        )
+        sp.add_argument(
+            "--species-order",
+            help=(
+                "comma-separated species names matching the species "
+                "columns of the orthologs table left-to-right. Overrides "
+                "header row + auto-detection."
+            ),
+        )
+        sp.add_argument(
+            "--header", action="store_true",
+            help="orthologs table has a header row with species names",
+        )
+        sp.add_argument(
+            "--orthogroup-id-col",
+            choices=["auto", "yes", "no"],
+            default="auto",
+            help=(
+                "whether the first column of the orthologs table is an "
+                "orthogroup identifier (Orthofinder style) rather than a "
+                "gene id. 'auto' detects from the column values."
+            ),
+        )
+        sp.set_defaults(handler=cmd_orthologs_to_rbh)
+
     # Register subcommands in the user-friendly order defined above.
     for name in SUBCOMMAND_ORDER:
         if name in SNAKEFILES:
@@ -503,6 +636,8 @@ def build_parser() -> argparse.ArgumentParser:
             _add_validate()
         elif name == "version":
             _add_version()
+        elif name == "orthologs-to-rbh":
+            _add_orthologs_to_rbh()
     return p
 
 
@@ -525,7 +660,7 @@ def main(argv: list[str] | None = None) -> int:
         argv = sys.argv[1:]
     if argv and argv[0] not in {"-h", "--help", "--version"} and not argv[0].startswith("-"):
         # All known subcommands across the parser.
-        valid = list(SNAKEFILES) + ["init", "validate", "version"]
+        valid = list(SNAKEFILES) + ["init", "validate", "version", "orthologs-to-rbh"]
         if argv[0] not in valid:
             guess = _suggest(argv[0], valid)
             sys.stderr.write(f"odp: unknown subcommand {argv[0]!r}\n")

--- a/source/orthofinder_importer.py
+++ b/source/orthofinder_importer.py
@@ -1,0 +1,704 @@
+"""Orthofinder-result importer with synteny-aware multi-copy disambiguation.
+
+This module turns a full Orthofinder run directory into an odp-style
+`.rbh` table without requiring the user to pre-filter to single-copy
+orthogroups. Multi-copy orthogroups, which would normally be discarded
+by a naive `fgrep -f Orthogroups_SingleCopyOrthologues.txt` pipeline,
+are rescued using one of several strategies — most usefully a
+synteny-anchored strategy that picks the candidate gene whose
+chromosome and position best fit the syntenic context established by
+the single-copy backbone.
+
+Strategies (selected via ``--multi-copy-strategy``):
+
+- ``skip``: drop every multi-copy orthogroup. Matches the behaviour of
+  naive Orthofinder → orthologs-table pipelines.
+- ``longest``: for each species with N>1 candidate genes in an
+  orthogroup, pick the longest CDS (``end - start``). No synteny
+  information needed. Fast but doesn't account for paralog placement.
+- ``most-common-chrom``: anchor-based, chromosome-only. For each
+  species pair (sp_A, sp_B) build a weighted chromosome compatibility
+  graph from the single-copy backbone, then for each multi-copy
+  ambiguity in sp_A, pick the candidate whose chromosome has the
+  highest weight to the chromosomes of the (single-copy) genes of the
+  other species in the same orthogroup.
+- ``synteny``: same as ``most-common-chrom`` but additionally rewards
+  candidates whose position is close to single-copy anchors on the
+  picked chromosome. Best signal, slower.
+
+Multi-copy orthogroups whose best candidate score in any species falls
+below ``--min-confidence`` are dropped (configurable; default 1).
+
+The module also writes an optional audit report — one row per
+(orthogroup, species) decision — recording the strategy used,
+candidate count, picked gene, picked score, and the second-best
+alternative.
+"""
+from __future__ import annotations
+
+import gzip
+import io
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Orthofinder run directory discovery
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OrthofinderPaths:
+    """Resolved locations of useful files inside an Orthofinder run dir."""
+    orthogroups_tsv: Path
+    single_copy_list: Optional[Path] = None
+    single_copy_sequences_dir: Optional[Path] = None
+    hierarchical_orthogroups_dir: Optional[Path] = None
+    resolved_gene_trees_dir: Optional[Path] = None
+
+
+def discover_orthofinder_paths(root: Path | str) -> OrthofinderPaths:
+    """Walk an Orthofinder run directory and resolve the useful subpaths.
+
+    Accepts either:
+    - the top-level Results_* directory (preferred), or
+    - the ``Orthogroups/`` subdirectory directly.
+
+    Raises ``FileNotFoundError`` if ``Orthogroups.tsv`` can't be found.
+    """
+    root = Path(root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"Orthofinder dir does not exist: {root}")
+
+    # Find Orthogroups/Orthogroups.tsv. Try root/Orthogroups first; if root
+    # IS the Orthogroups dir, look for the .tsv directly.
+    candidates = [
+        root / "Orthogroups" / "Orthogroups.tsv",
+        root / "Orthogroups.tsv",
+    ]
+    orthogroups_tsv = next((p for p in candidates if p.is_file()), None)
+    if orthogroups_tsv is None:
+        raise FileNotFoundError(
+            f"Could not find Orthogroups.tsv under {root}. Expected one of: "
+            f"{[str(p) for p in candidates]}"
+        )
+
+    out = OrthofinderPaths(orthogroups_tsv=orthogroups_tsv)
+
+    og_dir = orthogroups_tsv.parent
+    sc_list = og_dir / "Orthogroups_SingleCopyOrthologues.txt"
+    if sc_list.is_file():
+        out.single_copy_list = sc_list
+
+    sc_seq = root / "Single_Copy_Orthologue_Sequences"
+    if sc_seq.is_dir():
+        out.single_copy_sequences_dir = sc_seq
+
+    hho = root / "Phylogenetic_Hierarchical_Orthogroups"
+    if hho.is_dir():
+        out.hierarchical_orthogroups_dir = hho
+
+    rgt = root / "Resolved_Gene_Trees"
+    if rgt.is_dir():
+        out.resolved_gene_trees_dir = rgt
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Orthogroups.tsv parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_orthogroups_tsv(path: Path | str) -> Tuple[List[str], pd.DataFrame]:
+    """Parse Orthofinder ``Orthogroups.tsv``.
+
+    The file has a header row: ``Orthogroup<TAB>sp1<TAB>sp2<...>``. Each
+    data row is a single orthogroup. Each species cell may contain zero,
+    one, or many comma-separated (Orthofinder default: ``, ``) gene IDs.
+
+    Returns ``(species_names, dataframe)`` where the dataframe has one
+    column per species (named after the species) of ``list[str]`` gene
+    IDs, plus an ``OG`` column for the orthogroup ID.
+    """
+    path = Path(path)
+    # Tolerate CRLF and gzip.
+    if path.suffix == ".gz":
+        opener = lambda p: io.TextIOWrapper(gzip.open(p, "rb"), encoding="utf-8")
+    else:
+        opener = lambda p: open(p, "r", encoding="utf-8", newline="")
+
+    rows: List[List[str]] = []
+    with opener(path) as fh:
+        for raw in fh:
+            line = raw.rstrip("\r\n")
+            if not line.strip():
+                continue
+            rows.append(line.split("\t"))
+    if len(rows) < 2:
+        raise ValueError(f"Orthogroups.tsv {path} has no data rows")
+
+    header = rows[0]
+    if header[0] != "Orthogroup":
+        sys.stderr.write(
+            f"orthofinder-import: warning: header[0] of {path} is "
+            f"{header[0]!r}, expected 'Orthogroup'. Continuing.\n"
+        )
+    species = header[1:]
+    if not species:
+        raise ValueError(
+            f"Orthogroups.tsv {path}: header has no species columns"
+        )
+
+    data_rows: List[Dict] = []
+    for r in rows[1:]:
+        if len(r) != len(header):
+            # Pad or truncate: missing trailing cells = empty species.
+            r = (r + [""] * len(header))[: len(header)]
+        og_id = r[0]
+        record: Dict = {"OG": og_id}
+        for sp, cell in zip(species, r[1:]):
+            cell = cell.strip()
+            if not cell:
+                genes: List[str] = []
+            else:
+                # Orthofinder's default delimiter is ", ". Tolerate
+                # comma-only, tab-only, or whitespace-only separators.
+                genes = [t.strip() for t in cell.replace(",", " ").split() if t.strip()]
+            record[sp] = genes
+        data_rows.append(record)
+
+    return species, pd.DataFrame(data_rows)
+
+
+def load_single_copy_list(path: Path | str) -> set[str]:
+    """Read ``Orthogroups_SingleCopyOrthologues.txt`` (one OG id per line)."""
+    out: set[str] = set()
+    with open(path, "r", encoding="utf-8") as fh:
+        for raw in fh:
+            v = raw.strip()
+            if v:
+                out.add(v)
+    return out
+
+
+def partition_single_vs_multi_copy(
+    df: pd.DataFrame,
+    species: Sequence[str],
+    explicit_single_copy: Optional[set[str]] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split orthogroups into single-copy (exactly one gene per species,
+    no zero cells) and everything-else.
+
+    If ``explicit_single_copy`` is supplied (e.g. read from
+    ``Orthogroups_SingleCopyOrthologues.txt``), that set defines the
+    single-copy partition. Otherwise, the partition is computed from the
+    cell contents.
+    """
+    if explicit_single_copy is not None:
+        single_mask = df["OG"].isin(explicit_single_copy)
+    else:
+        # `.map` was renamed from `.applymap` in pandas 2.1; .applymap still
+        # works on 2.x but warns. Use .apply(lambda col: col.map(...)) for
+        # cross-version compatibility without triggering the deprecation.
+        single_mask = df[species].apply(
+            lambda col: col.map(lambda v: len(v) == 1)
+        ).all(axis=1)
+    single = df[single_mask].copy()
+    multi = df[~single_mask].copy()
+    return single, multi
+
+
+# ---------------------------------------------------------------------------
+# Anchor graph from single-copy backbone
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AnchorGraph:
+    """Per-species-pair chromosome compatibility graph derived from the
+    single-copy orthogroup backbone.
+
+    ``edge[(sp_a, sp_b)][(chr_a, chr_b)] = count`` — the number of
+    single-copy orthogroups where sp_a's gene is on ``chr_a`` and sp_b's
+    gene is on ``chr_b``.
+
+    ``positions[sp][chr] = sorted list of int positions of single-copy
+    anchor genes on that chromosome``. Used for proximity scoring in the
+    ``synteny`` strategy.
+    """
+    edge: Dict[Tuple[str, str], Dict[Tuple[str, str], int]]
+    positions: Dict[str, Dict[str, List[int]]]
+
+
+def build_anchor_graph(
+    single_copy_df: pd.DataFrame,
+    species: Sequence[str],
+    coords: Dict[str, pd.DataFrame],
+) -> AnchorGraph:
+    """Compute the chromosome-pair edge weights and per-species anchor
+    positions from the single-copy orthogroup backbone.
+
+    ``coords[sp]`` must be a DataFrame with at least ``gene_id``,
+    ``chrom``, and ``pos`` columns (produced by
+    ``ortholog_table_importer.parse_coordinates``).
+    """
+    edge: Dict[Tuple[str, str], Dict[Tuple[str, str], int]] = {}
+    positions: Dict[str, Dict[str, List[int]]] = {sp: {} for sp in species}
+
+    # Pre-build per-species gene -> (chrom, pos) lookups.
+    lookup: Dict[str, Dict[str, Tuple[str, int]]] = {}
+    for sp in species:
+        df = coords[sp]
+        lookup[sp] = dict(zip(df["gene_id"], zip(df["chrom"], df["pos"])))
+
+    for _, row in single_copy_df.iterrows():
+        gene_per_sp: Dict[str, Tuple[str, int]] = {}
+        skip = False
+        for sp in species:
+            genes = row[sp]
+            if len(genes) != 1:
+                # Defensive: should never happen if the partition is right.
+                skip = True
+                break
+            info = lookup[sp].get(genes[0])
+            if info is None:
+                # Gene not in the coord file — drop this row from the
+                # anchor backbone. It can't anchor anything.
+                skip = True
+                break
+            gene_per_sp[sp] = info
+        if skip:
+            continue
+
+        for sp, (chrom, pos) in gene_per_sp.items():
+            positions[sp].setdefault(chrom, []).append(pos)
+
+        # Pairwise edges (directed both ways).
+        species_list = list(gene_per_sp.keys())
+        for i, sp_a in enumerate(species_list):
+            chr_a = gene_per_sp[sp_a][0]
+            for sp_b in species_list[i + 1:]:
+                chr_b = gene_per_sp[sp_b][0]
+                key = (sp_a, sp_b)
+                rev_key = (sp_b, sp_a)
+                edge.setdefault(key, {})
+                edge.setdefault(rev_key, {})
+                edge[key][(chr_a, chr_b)] = edge[key].get((chr_a, chr_b), 0) + 1
+                edge[rev_key][(chr_b, chr_a)] = edge[rev_key].get((chr_b, chr_a), 0) + 1
+
+    for sp in species:
+        for chrom in positions[sp]:
+            positions[sp][chrom].sort()
+
+    return AnchorGraph(edge=edge, positions=positions)
+
+
+# ---------------------------------------------------------------------------
+# Disambiguation strategies
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DisambDecision:
+    """One species-level pick within an orthogroup, for audit purposes."""
+    og: str
+    species: str
+    strategy: str
+    n_candidates: int
+    picked_gene: Optional[str]
+    picked_score: float
+    second_best_gene: Optional[str]
+    second_best_score: Optional[float]
+    reason: str
+
+
+def _nearest_anchor_distance(positions: List[int], pos: int) -> int:
+    """Return the distance (in bp) from ``pos`` to the nearest entry in
+    the sorted ``positions`` list. Empty list returns a sentinel (10 Mbp)."""
+    if not positions:
+        return 10_000_000
+    import bisect
+    idx = bisect.bisect_left(positions, pos)
+    candidates = []
+    if idx > 0:
+        candidates.append(abs(pos - positions[idx - 1]))
+    if idx < len(positions):
+        candidates.append(abs(pos - positions[idx]))
+    return min(candidates) if candidates else 10_000_000
+
+
+def _candidates_for(
+    species: str,
+    genes: List[str],
+    coords_lookup: Dict[str, Dict[str, Tuple[str, int, int, int]]],
+) -> List[Tuple[str, str, int, int]]:
+    """Return list of ``(gene_id, chrom, pos, length)`` for the given
+    gene IDs, dropping any that aren't in the coord file."""
+    out: List[Tuple[str, str, int, int]] = []
+    sp_lookup = coords_lookup[species]
+    for g in genes:
+        info = sp_lookup.get(g)
+        if info is not None:
+            chrom, pos, start, end = info
+            out.append((g, chrom, pos, end - start))
+    return out
+
+
+def disambiguate_multicopy(
+    multi_copy_df: pd.DataFrame,
+    species: Sequence[str],
+    coords: Dict[str, pd.DataFrame],
+    anchor_graph: Optional[AnchorGraph],
+    strategy: str,
+    min_confidence: float = 1.0,
+) -> Tuple[pd.DataFrame, List[DisambDecision]]:
+    """Apply ``strategy`` to each multi-copy orthogroup. Returns
+
+      (resolved_single_copy_df, audit_decisions)
+
+    where ``resolved_single_copy_df`` has the same shape as the
+    single-copy partition (one gene per species per row, as a 1-element
+    list in each species column) for orthogroups that survive, and
+    ``audit_decisions`` records every decision for the report.
+
+    For ``strategy == 'skip'``, ``resolved_single_copy_df`` is empty.
+    For ``strategy == 'longest'``, no anchor graph is needed; pass None.
+    For ``most-common-chrom`` and ``synteny``, ``anchor_graph`` is
+    required and must be built from the single-copy backbone.
+    """
+    if strategy == "skip":
+        return pd.DataFrame(columns=multi_copy_df.columns), []
+
+    valid = {"longest", "most-common-chrom", "synteny"}
+    if strategy not in valid:
+        raise ValueError(
+            f"unknown multi-copy strategy: {strategy!r}. Choose one of "
+            f"{sorted({'skip'} | valid)}."
+        )
+
+    if strategy in ("most-common-chrom", "synteny") and anchor_graph is None:
+        raise ValueError(
+            f"strategy {strategy!r} needs an anchor graph built from "
+            f"single-copy orthogroups."
+        )
+
+    # gene_id -> (chrom, pos, start, end) per species, for length + position.
+    coords_lookup: Dict[str, Dict[str, Tuple[str, int, int, int]]] = {}
+    for sp in species:
+        df = coords[sp]
+        coords_lookup[sp] = {
+            row["gene_id"]: (row["chrom"], row["pos"], row["start"], row["end"])
+            for _, row in df.iterrows()
+        }
+
+    resolved_rows: List[Dict] = []
+    audit: List[DisambDecision] = []
+
+    for _, og_row in multi_copy_df.iterrows():
+        og = og_row["OG"]
+        picked: Dict[str, str] = {}
+        og_kept = True
+
+        # First pass: species that already have exactly one candidate need
+        # no disambiguation — record the single gene and move on. These
+        # rows serve as "given" context when scoring multi-copy species
+        # in the same OG.
+        species_to_disambiguate: List[str] = []
+        for sp in species:
+            genes = og_row[sp]
+            if len(genes) == 0:
+                # Missing species — this OG can't be a complete single-
+                # copy row across all species. Skip.
+                og_kept = False
+                audit.append(DisambDecision(
+                    og=og, species=sp, strategy=strategy,
+                    n_candidates=0, picked_gene=None, picked_score=0.0,
+                    second_best_gene=None, second_best_score=None,
+                    reason="no candidates in this species",
+                ))
+                break
+            if len(genes) == 1:
+                picked[sp] = genes[0]
+            else:
+                species_to_disambiguate.append(sp)
+        if not og_kept:
+            continue
+
+        # Second pass: for each multi-copy species, score candidates.
+        for sp in species_to_disambiguate:
+            cands = _candidates_for(sp, og_row[sp], coords_lookup)
+            if not cands:
+                audit.append(DisambDecision(
+                    og=og, species=sp, strategy=strategy,
+                    n_candidates=len(og_row[sp]),
+                    picked_gene=None, picked_score=0.0,
+                    second_best_gene=None, second_best_score=None,
+                    reason="no candidate gene found in coord file",
+                ))
+                og_kept = False
+                break
+
+            scored: List[Tuple[float, str, str]] = []  # (score, gene, reason)
+
+            if strategy == "longest":
+                for gene, chrom, pos, length in cands:
+                    scored.append((float(length), gene, f"length={length}"))
+            else:
+                # most-common-chrom or synteny: use anchor graph.
+                other_sp_genes: Dict[str, Tuple[str, int]] = {}
+                for other_sp in species:
+                    if other_sp == sp:
+                        continue
+                    if other_sp not in picked:
+                        # Another multi-copy species we haven't resolved
+                        # yet; skip — only score against already-resolved
+                        # species (single-copy + earlier picks).
+                        continue
+                    info = coords_lookup[other_sp].get(picked[other_sp])
+                    if info is not None:
+                        other_sp_genes[other_sp] = (info[0], info[1])
+
+                for gene, chrom, pos, length in cands:
+                    chrom_score = 0.0
+                    for other_sp, (other_chr, _other_pos) in other_sp_genes.items():
+                        key = (sp, other_sp)
+                        weight = anchor_graph.edge.get(key, {}).get((chrom, other_chr), 0)
+                        chrom_score += weight
+
+                    if strategy == "synteny":
+                        anchor_positions = anchor_graph.positions.get(sp, {}).get(chrom, [])
+                        nearest = _nearest_anchor_distance(anchor_positions, pos)
+                        # Decay: 1 / (1 + distance_in_Mbp). Anchors within
+                        # 1 Mbp give a boost ~0.5; 10 Mbp gives ~0.1; 100
+                        # Mbp gives ~0.01. Bounded contribution so a single
+                        # chromosome-pair vote always beats positional
+                        # tiebreaking.
+                        proximity = 1.0 / (1.0 + nearest / 1_000_000.0)
+                        score = chrom_score + 0.5 * proximity
+                        reason = f"chrom={chrom_score:.0f} prox={proximity:.3f}"
+                    else:  # most-common-chrom
+                        score = chrom_score
+                        reason = f"chrom={chrom_score:.0f}"
+
+                    scored.append((score, gene, reason))
+
+            # Pick highest. Tie-break by length (descending), then alphabetic.
+            scored.sort(key=lambda t: (-t[0], -coords_lookup[sp][t[1]][3] + coords_lookup[sp][t[1]][2], t[1]))
+            best_score, best_gene, best_reason = scored[0]
+            second_gene = scored[1][1] if len(scored) > 1 else None
+            second_score = scored[1][0] if len(scored) > 1 else None
+
+            audit.append(DisambDecision(
+                og=og, species=sp, strategy=strategy,
+                n_candidates=len(cands),
+                picked_gene=best_gene, picked_score=best_score,
+                second_best_gene=second_gene, second_best_score=second_score,
+                reason=best_reason,
+            ))
+
+            if best_score < min_confidence:
+                og_kept = False
+                # Mark in the audit reason for clarity.
+                audit[-1] = DisambDecision(
+                    og=og, species=sp, strategy=strategy,
+                    n_candidates=len(cands),
+                    picked_gene=best_gene, picked_score=best_score,
+                    second_best_gene=second_gene, second_best_score=second_score,
+                    reason=audit[-1].reason + f"; BELOW min-confidence {min_confidence}",
+                )
+                break
+
+            picked[sp] = best_gene
+
+        if og_kept:
+            row: Dict = {"OG": og}
+            for sp in species:
+                row[sp] = [picked[sp]]
+            resolved_rows.append(row)
+
+    if resolved_rows:
+        resolved = pd.DataFrame(resolved_rows)
+    else:
+        resolved = pd.DataFrame(columns=multi_copy_df.columns)
+    return resolved, audit
+
+
+# ---------------------------------------------------------------------------
+# Emit .rbh
+# ---------------------------------------------------------------------------
+
+
+def emit_rbh_from_orthogroups(
+    df: pd.DataFrame,
+    species: Sequence[str],
+    coords: Dict[str, pd.DataFrame],
+) -> pd.DataFrame:
+    """Convert a single-copy-per-row orthogroup DataFrame (with list-valued
+    species columns of length 1) into an odp-style .rbh DataFrame."""
+    # Pre-build coord lookups.
+    lookup: Dict[str, Dict[str, Tuple[str, int]]] = {}
+    for sp in species:
+        cdf = coords[sp]
+        lookup[sp] = dict(zip(cdf["gene_id"], zip(cdf["chrom"], cdf["pos"])))
+
+    out_rows: List[Dict] = []
+    skipped = 0
+    for _, row in df.iterrows():
+        new_row: Dict = {"rbh": "", "gene_group": "None"}
+        skip = False
+        for sp in species:
+            gene_list = row[sp]
+            gene = gene_list[0] if gene_list else None
+            if gene is None:
+                skip = True
+                break
+            info = lookup[sp].get(gene)
+            if info is None:
+                skip = True
+                break
+            chrom, pos = info
+            new_row[f"{sp}_gene"] = gene
+            new_row[f"{sp}_scaf"] = chrom
+            new_row[f"{sp}_pos"] = pos
+        if skip:
+            skipped += 1
+            continue
+        out_rows.append(new_row)
+
+    if skipped:
+        sys.stderr.write(
+            f"orthofinder-import: emit_rbh dropped {skipped} OGs with "
+            f"genes missing from coord files.\n"
+        )
+    if not out_rows:
+        return pd.DataFrame(columns=["rbh", "gene_group"] + [
+            f"{sp}_{kind}" for sp in species for kind in ("gene", "scaf", "pos")
+        ])
+
+    for i, r in enumerate(out_rows, start=1):
+        r["rbh"] = f"rbh{i}"
+
+    col_order = ["rbh", "gene_group"]
+    for sp in species:
+        col_order += [f"{sp}_gene", f"{sp}_scaf", f"{sp}_pos"]
+    return pd.DataFrame(out_rows)[col_order]
+
+
+# ---------------------------------------------------------------------------
+# Audit report
+# ---------------------------------------------------------------------------
+
+
+def write_audit_report(decisions: List[DisambDecision], path: Path | str) -> int:
+    """Write the disambiguation audit as a TSV. Returns row count."""
+    if not decisions:
+        Path(path).write_text(
+            "OG\tspecies\tstrategy\tn_candidates\tpicked_gene\t"
+            "picked_score\tsecond_best_gene\tsecond_best_score\treason\n"
+        )
+        return 0
+    rows = [
+        {
+            "OG": d.og,
+            "species": d.species,
+            "strategy": d.strategy,
+            "n_candidates": d.n_candidates,
+            "picked_gene": d.picked_gene if d.picked_gene is not None else "",
+            "picked_score": f"{d.picked_score:.4f}",
+            "second_best_gene": d.second_best_gene if d.second_best_gene is not None else "",
+            "second_best_score": f"{d.second_best_score:.4f}" if d.second_best_score is not None else "",
+            "reason": d.reason,
+        }
+        for d in decisions
+    ]
+    pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry
+# ---------------------------------------------------------------------------
+
+
+def orthofinder_to_rbh(
+    orthofinder_dir: Path | str,
+    coord_paths: Dict[str, Path | str],
+    strategy: str = "synteny",
+    min_confidence: float = 1.0,
+) -> Tuple[pd.DataFrame, List[DisambDecision]]:
+    """Top-level: walk the Orthofinder dir, parse Orthogroups.tsv, build
+    the anchor graph from single-copy orthogroups, disambiguate multi-
+    copy orthogroups per the chosen strategy, and emit a unified .rbh
+    DataFrame along with an audit list.
+
+    Args:
+      orthofinder_dir: top-level Orthofinder run directory.
+      coord_paths: ``{species: path}``. Species names must match the
+        column names in ``Orthogroups.tsv``. Each path may point at a
+        .chrom or BED file (gzip-OK; format auto-detected).
+      strategy: ``'skip'``, ``'longest'``, ``'most-common-chrom'``, or
+        ``'synteny'``.
+      min_confidence: orthogroups whose best per-species score in
+        any species falls below this threshold are dropped (only
+        meaningful for ``most-common-chrom`` and ``synteny``).
+    """
+    # Lazy import to avoid coupling at module import time.
+    from ortholog_table_importer import parse_coordinates
+
+    paths = discover_orthofinder_paths(orthofinder_dir)
+    species, og_df = parse_orthogroups_tsv(paths.orthogroups_tsv)
+
+    missing = [s for s in species if s not in coord_paths]
+    if missing:
+        raise ValueError(
+            f"Coord file missing for species {missing!r}. The Orthofinder "
+            f"Orthogroups.tsv has columns {species!r}; supply --chrom or "
+            f"--bed for every one."
+        )
+
+    coords: Dict[str, pd.DataFrame] = {}
+    for sp in species:
+        coords[sp] = parse_coordinates(coord_paths[sp])
+
+    # Partition into single-copy + multi-copy.
+    explicit_sc = None
+    if paths.single_copy_list is not None:
+        explicit_sc = load_single_copy_list(paths.single_copy_list)
+    single_df, multi_df = partition_single_vs_multi_copy(
+        og_df, species, explicit_single_copy=explicit_sc
+    )
+
+    sys.stderr.write(
+        f"orthofinder-import: {len(single_df)} single-copy OGs, "
+        f"{len(multi_df)} multi-copy OGs. Strategy: {strategy}.\n"
+    )
+
+    if strategy == "skip":
+        anchor_graph = None
+        resolved_df = pd.DataFrame(columns=multi_df.columns)
+        audit: List[DisambDecision] = []
+    elif strategy == "longest":
+        anchor_graph = None
+        resolved_df, audit = disambiguate_multicopy(
+            multi_df, species, coords, None, strategy, min_confidence
+        )
+    else:
+        anchor_graph = build_anchor_graph(single_df, species, coords)
+        resolved_df, audit = disambiguate_multicopy(
+            multi_df, species, coords, anchor_graph, strategy, min_confidence
+        )
+
+    sys.stderr.write(
+        f"orthofinder-import: rescued {len(resolved_df)}/{len(multi_df)} "
+        f"multi-copy OGs.\n"
+    )
+
+    # Combine single + resolved-multi into one frame, then emit .rbh.
+    combined = pd.concat([single_df, resolved_df], ignore_index=True)
+    rbh = emit_rbh_from_orthogroups(combined, species, coords)
+    return rbh, audit

--- a/source/orthofinder_importer.py
+++ b/source/orthofinder_importer.py
@@ -469,6 +469,20 @@ def disambiguate_multicopy(
                         key = (sp, other_sp)
                         weight = anchor_graph.edge.get(key, {}).get((chrom, other_chr), 0)
                         chrom_score += weight
+                    # Fallback: when no within-OG partners are resolved yet
+                    # (e.g. the OG is multi-copy in every species), score
+                    # this candidate by its chromosome's total backbone
+                    # weight to every other species. Without this, the
+                    # first multi-copy species in any all-multi-copy OG
+                    # always scores 0 and the OG gets dropped.
+                    if not other_sp_genes:
+                        for other_sp in species:
+                            if other_sp == sp:
+                                continue
+                            key = (sp, other_sp)
+                            for (a, _b), w in anchor_graph.edge.get(key, {}).items():
+                                if a == chrom:
+                                    chrom_score += w
 
                     if strategy == "synteny":
                         anchor_positions = anchor_graph.positions.get(sp, {}).get(chrom, [])

--- a/source/ortholog_table_importer.py
+++ b/source/ortholog_table_importer.py
@@ -30,6 +30,8 @@ No new dependencies. Standard library + pandas (already a runtime dep).
 from __future__ import annotations
 
 import csv
+import gzip
+import io
 import sys
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
@@ -38,29 +40,123 @@ import pandas as pd
 
 
 # ---------------------------------------------------------------------------
-# BED parsing
+# Coordinate file parsing (.chrom and BED)
 # ---------------------------------------------------------------------------
+
+
+def _open_text_maybe_gzip(path: Path | str) -> io.TextIOBase:
+    """Open a path as text. Handles gzip by magic bytes (not extension)."""
+    path = Path(path)
+    with open(path, "rb") as fh:
+        head = fh.read(2)
+    if head == b"\x1f\x8b":
+        return io.TextIOWrapper(gzip.open(path, "rb"), encoding="utf-8")
+    return open(path, "r", encoding="utf-8", newline="")
+
+
+def detect_coord_format(path: Path | str) -> str:
+    """Return ``'chrom'``, ``'bed'``, or raise. Inspects the first non-empty
+    line:
+
+    - ``.chrom``: 5 columns; col 3 is ``+``/``-``/``.``; cols 4-5 are int.
+    - BED:        4+ columns; cols 2-3 are int; col 1 is the chromosome.
+    """
+    with _open_text_maybe_gzip(path) as fh:
+        for raw in fh:
+            line = raw.rstrip("\r\n")
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            # chrom format: col[2] in {'+','-','.'} and cols 3, 4 are int
+            if (
+                len(parts) >= 5
+                and parts[2] in ("+", "-", ".")
+                and parts[3].lstrip("-").isdigit()
+                and parts[4].lstrip("-").isdigit()
+            ):
+                return "chrom"
+            # BED format: cols 1, 2 are int
+            if (
+                len(parts) >= 4
+                and parts[1].lstrip("-").isdigit()
+                and parts[2].lstrip("-").isdigit()
+            ):
+                return "bed"
+            raise ValueError(
+                f"Coordinate file {path} line 1: cannot detect format. "
+                f"Expected either odp .chrom (gene_id, chrom, +/-/., start, "
+                f"stop) or BED (chrom, start, end, gene_id). Got: {parts!r}"
+            )
+    raise ValueError(f"Coordinate file {path} is empty")
+
+
+def parse_chrom(path: Path | str) -> pd.DataFrame:
+    """Read an odp ``.chrom`` file (5 tab-separated fields: ``gene_id``,
+    ``scaffold``, ``strand``, ``start``, ``stop``). Transparently handles
+    gzip-compressed input (``.chrom.gz``).
+
+    Returns a DataFrame with columns: ``chrom`` (str), ``start`` (int),
+    ``end`` (int), ``gene_id`` (str), ``strand`` (str), ``pos`` (int —
+    gene midpoint).
+    """
+    path = Path(path)
+    rows: list[dict] = []
+    with _open_text_maybe_gzip(path) as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\r\n")
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            if len(parts) < 5:
+                raise ValueError(
+                    f".chrom file {path} line {lineno}: needs at least 5 "
+                    f"tab-separated columns (gene_id, scaffold, strand, "
+                    f"start, stop), got {len(parts)}: {parts!r}"
+                )
+            gene_id, chrom, strand, start_s, stop_s = parts[:5]
+            if strand not in ("+", "-", "."):
+                raise ValueError(
+                    f".chrom file {path} line {lineno}: strand must be "
+                    f"'+', '-', or '.', got {strand!r}"
+                )
+            try:
+                start = int(start_s)
+                end = int(stop_s)
+            except ValueError as e:
+                raise ValueError(
+                    f".chrom file {path} line {lineno}: start/stop must be "
+                    f"integers, got {start_s!r}/{stop_s!r}"
+                ) from e
+            rows.append({
+                "chrom": chrom,
+                "start": start,
+                "end": end,
+                "gene_id": gene_id,
+                "strand": strand,
+                "pos": (start + end) // 2,
+            })
+    if not rows:
+        raise ValueError(f".chrom file {path} is empty or has no parseable lines")
+    return pd.DataFrame(rows)
 
 
 def parse_bed(path: Path | str) -> pd.DataFrame:
     """Read a BED-like file with at least four columns
     (``chrom``, ``start``, ``end``, ``gene_id``). Trailing columns are kept
-    but unused. Strips CRLF and skips blank lines.
+    but unused. Strips CRLF and skips blank lines. Transparently handles
+    gzip-compressed input.
 
     Returns a DataFrame with columns: ``chrom`` (str), ``start`` (int),
     ``end`` (int), ``gene_id`` (str), ``pos`` (int — gene midpoint).
     """
     path = Path(path)
     rows: list[dict] = []
-    with open(path, "r", encoding="utf-8", newline="") as fh:
-        reader = csv.reader(fh, delimiter="\t")
-        for lineno, parts in enumerate(reader, start=1):
-            if not parts:
+    with _open_text_maybe_gzip(path) as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\r\n")
+            if not line.strip():
                 continue
-            # Tolerate a single line accidentally written with CRLF only
-            parts = [c.replace("\r", "") for c in parts]
-            if not any(p.strip() for p in parts):
-                continue
+            parts = line.split("\t")
             if len(parts) < 4:
                 raise ValueError(
                     f"BED file {path} line {lineno}: needs at least 4 tab-"
@@ -86,6 +182,26 @@ def parse_bed(path: Path | str) -> pd.DataFrame:
     if not rows:
         raise ValueError(f"BED file {path} is empty or has no parseable lines")
     return pd.DataFrame(rows)
+
+
+def parse_coordinates(path: Path | str, fmt: str = "auto") -> pd.DataFrame:
+    """Parse a coordinate file in either odp .chrom or BED format.
+
+    Args:
+      path: file path (gzip-compressed accepted).
+      fmt: ``'auto'`` (default), ``'chrom'``, or ``'bed'``. With ``'auto'``,
+        the format is detected from the first non-empty line.
+
+    Returns a DataFrame with columns ``chrom``, ``start``, ``end``,
+    ``gene_id``, ``pos`` (and ``strand`` if the input was .chrom).
+    """
+    if fmt == "auto":
+        fmt = detect_coord_format(path)
+    if fmt == "chrom":
+        return parse_chrom(path)
+    if fmt == "bed":
+        return parse_bed(path)
+    raise ValueError(f"unsupported coordinate format: {fmt!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -261,12 +377,15 @@ def orthologs_to_rbh(
     has_header: bool = False,
     has_orthogroup_id_column: Optional[bool] = None,
 ) -> pd.DataFrame:
-    """Join an N-column ortholog table against per-species BED files and
-    return an odp-style `.rbh` DataFrame.
+    """Join an N-column ortholog table against per-species coordinate
+    files and return an odp-style `.rbh` DataFrame.
 
     Args:
       orthologs_path: path to the tab-separated orthologs table.
-      bed_paths: mapping of species name → path to that species' BED.
+      bed_paths: mapping of species name → path to that species'
+        coordinate file. odp ``.chrom`` and BED formats are both
+        accepted; the format is auto-detected from file content.
+        gzip-compressed inputs are handled transparently.
       species_order: if supplied, the species columns of the orthologs
         table are interpreted in this order (overrides any header row
         and disables auto-detection of an orthogroup-id column).
@@ -285,19 +404,20 @@ def orthologs_to_rbh(
         has_header=has_header,
     )
 
-    # Every species in the table must have a BED.
+    # Every species in the table must have a coordinate file.
     missing_beds = [s for s in species_names if s not in bed_paths]
     if missing_beds:
         raise ValueError(
-            f"BED files missing for species {missing_beds!r}. The orthologs "
-            f"table has columns {species_names!r}; --bed must be supplied "
-            f"for every one."
+            f"Coordinate files missing for species {missing_beds!r}. The "
+            f"orthologs table has columns {species_names!r}; --bed or "
+            f"--chrom must be supplied for every one."
         )
 
-    # Load BEDs and build per-species gene-id → (chrom, pos) lookup.
+    # Load coordinate files (auto-detect chrom vs BED) and build
+    # per-species gene-id → (chrom, pos) lookup.
     sp_lookup: Dict[str, Dict[str, Tuple[str, int]]] = {}
     for sp in species_names:
-        bed_df = parse_bed(bed_paths[sp])
+        bed_df = parse_coordinates(bed_paths[sp])
         # If a gene id is duplicated in the BED, keep the first; warn.
         dup_mask = bed_df["gene_id"].duplicated()
         if dup_mask.any():

--- a/source/ortholog_table_importer.py
+++ b/source/ortholog_table_importer.py
@@ -1,0 +1,364 @@
+"""Generic ortholog-table importers and friends.
+
+Provides paths into odp's `.rbh`-based pipeline that don't require the user
+to run the full diamond / blastp reciprocal-best-hits step. Two input
+shapes are supported:
+
+* **Orthofinder output.** Either the raw `Orthogroups.tsv` filtered to
+  single-copy orthologs, or any tab-separated file with one column per
+  species and one row per orthogroup.
+* **Plain N-column orthologs table.** Tab-separated, no orthogroup ID
+  column. One column per species, one row per ortholog tuple.
+
+Both shapes are joined against per-species BED files
+(``chrom``/``start``/``end``/``gene_id`` minimum) and emitted as an
+odp-compatible `.rbh` table with the columns:
+
+* ``rbh`` — synthetic identifier, ``rbhN`` where N is the row index
+* ``gene_group`` — ``"None"`` by default (downstream tools fill it in)
+* ``<species>_gene`` — gene identifier for each species
+* ``<species>_scaf`` — chromosome / scaffold name for each species
+* ``<species>_pos`` — midpoint of the gene's BED coordinates (``(start+end)//2``)
+
+This lets users with pre-computed orthology (Orthofinder runs, in-house
+RBH workflows, manually curated ortholog tables) skip the all-vs-all
+search and feed orthologs straight into ``odp run`` / ``odp nway-rbh``
+/ downstream plotters.
+
+No new dependencies. Standard library + pandas (already a runtime dep).
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# BED parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_bed(path: Path | str) -> pd.DataFrame:
+    """Read a BED-like file with at least four columns
+    (``chrom``, ``start``, ``end``, ``gene_id``). Trailing columns are kept
+    but unused. Strips CRLF and skips blank lines.
+
+    Returns a DataFrame with columns: ``chrom`` (str), ``start`` (int),
+    ``end`` (int), ``gene_id`` (str), ``pos`` (int — gene midpoint).
+    """
+    path = Path(path)
+    rows: list[dict] = []
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        for lineno, parts in enumerate(reader, start=1):
+            if not parts:
+                continue
+            # Tolerate a single line accidentally written with CRLF only
+            parts = [c.replace("\r", "") for c in parts]
+            if not any(p.strip() for p in parts):
+                continue
+            if len(parts) < 4:
+                raise ValueError(
+                    f"BED file {path} line {lineno}: needs at least 4 tab-"
+                    f"separated columns (chrom, start, end, gene_id), got "
+                    f"{len(parts)}: {parts!r}"
+                )
+            chrom, start_s, end_s, gene_id = parts[0], parts[1], parts[2], parts[3]
+            try:
+                start = int(start_s)
+                end = int(end_s)
+            except ValueError as e:
+                raise ValueError(
+                    f"BED file {path} line {lineno}: start/end must be "
+                    f"integers, got {start_s!r}/{end_s!r}"
+                ) from e
+            rows.append({
+                "chrom": chrom,
+                "start": start,
+                "end": end,
+                "gene_id": gene_id,
+                "pos": (start + end) // 2,
+            })
+    if not rows:
+        raise ValueError(f"BED file {path} is empty or has no parseable lines")
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Orthologs-table parsing
+# ---------------------------------------------------------------------------
+
+
+def _read_tsv_skipping_blanks(path: Path) -> List[List[str]]:
+    """Read a TSV with tolerance for CRLF line endings and blank lines."""
+    with open(path, "rb") as fh:
+        raw = fh.read()
+    # Normalise line endings: Orthofinder output is "ASCII with CRLF
+    # terminators" on common installs. csv.reader handles \r\n but not
+    # bare \r, so we standardise to \n up front.
+    text = raw.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+    out: list[list[str]] = []
+    for line in text.split("\n"):
+        if not line.strip():
+            continue
+        out.append(line.split("\t"))
+    return out
+
+
+def parse_ortholog_table(
+    path: Path | str,
+    species_names: Optional[Sequence[str]] = None,
+    has_orthogroup_id_column: Optional[bool] = None,
+    has_header: bool = False,
+) -> Tuple[List[str], pd.DataFrame]:
+    """Parse an N-column ortholog table.
+
+    The table is tab-separated with one row per ortholog tuple and one
+    column per species (optionally preceded by an orthogroup-id column,
+    which is the shape of Orthofinder's ``Orthogroups.tsv``).
+
+    Args:
+      path: input path.
+      species_names: optional list of species names matching the species
+        columns left-to-right. If omitted and the file has a header row,
+        the header is used.
+      has_orthogroup_id_column: True if the first column is an orthogroup
+        identifier rather than a gene. If None, the function auto-detects:
+        the column is treated as an orthogroup id if every value matches
+        ``^[A-Za-z]+\\d+$`` (e.g. ``OG0000001``).
+      has_header: True if the first row is a header.
+
+    Returns:
+      ``(species_names, dataframe)`` where the dataframe has one column
+      per species named after that species, each cell being a gene id.
+
+    Single-copy orthologs in Orthofinder put exactly one gene per species
+    per row. Multi-copy rows (rare but possible if the user feeds the
+    full ``Orthogroups.tsv`` instead of the single-copy subset) are
+    rejected with a clear error message — the .rbh format assumes one
+    gene per species per row.
+    """
+    path = Path(path)
+    rows = _read_tsv_skipping_blanks(path)
+    if not rows:
+        raise ValueError(f"Orthologs table {path} is empty")
+
+    if has_header:
+        header_row = rows[0]
+        data_rows = rows[1:]
+    else:
+        header_row = None
+        data_rows = rows
+
+    if not data_rows:
+        raise ValueError(f"Orthologs table {path} has no data rows")
+
+    ncols = len(data_rows[0])
+    if any(len(r) != ncols for r in data_rows):
+        bad = next(i for i, r in enumerate(data_rows, start=1) if len(r) != ncols)
+        raise ValueError(
+            f"Orthologs table {path}: inconsistent column count. Row {bad} "
+            f"has {len(data_rows[bad-1])} columns, first row has {ncols}."
+        )
+
+    # Auto-detect orthogroup-id column.
+    #
+    # Pattern matches real Orthofinder-style identifiers (OG0000001) and
+    # similar — at least two letters followed by at least four digits.
+    # A bare "g1" is NOT an orthogroup id and should be treated as a gene.
+    #
+    # If `species_names` is supplied explicitly and the column count is
+    # exactly one greater than the species count, we infer the leading
+    # column is an OG identifier even if it doesn't match the regex
+    # (allows custom-format OG ids).
+    if has_orthogroup_id_column is None:
+        if species_names is not None:
+            # User told us the species; the column count vs. species count
+            # disambiguates whether there's a leading OG column.
+            if ncols == len(species_names):
+                has_orthogroup_id_column = False
+            elif ncols == len(species_names) + 1:
+                has_orthogroup_id_column = True
+            else:
+                raise ValueError(
+                    f"Orthologs table {path}: --species-order has "
+                    f"{len(species_names)} entries but the table has "
+                    f"{ncols} columns. Expected either {len(species_names)} "
+                    f"(no OG id column) or {len(species_names) + 1} (one "
+                    f"OG id column followed by species)."
+                )
+        else:
+            import re
+            og_pattern = re.compile(r"^[A-Za-z]{2,}\d{4,}$")
+            first_col = [r[0] for r in data_rows]
+            has_orthogroup_id_column = all(og_pattern.match(v) for v in first_col)
+
+    if has_orthogroup_id_column:
+        species_cols = list(range(1, ncols))
+    else:
+        species_cols = list(range(ncols))
+
+    # Determine species names.
+    if species_names is not None:
+        if len(species_names) != len(species_cols):
+            raise ValueError(
+                f"Orthologs table {path}: --species-order has "
+                f"{len(species_names)} entries but the table has "
+                f"{len(species_cols)} species columns."
+            )
+        names = list(species_names)
+    elif header_row is not None:
+        names = [header_row[i] for i in species_cols]
+    else:
+        names = [f"sp{i+1}" for i in range(len(species_cols))]
+
+    # Build the dataframe.
+    out_rows: list[dict] = []
+    for r_idx, r in enumerate(data_rows, start=1):
+        row_dict: dict = {}
+        for col_idx, sp in zip(species_cols, names):
+            cell = r[col_idx].strip()
+            if not cell:
+                raise ValueError(
+                    f"Orthologs table {path}: row {r_idx} has an empty cell "
+                    f"for species {sp!r}. Orthologs tables fed to "
+                    f"orthologs-to-rbh must have one gene per species per "
+                    f"row. Pre-filter to the single-copy subset (e.g. via "
+                    f"Orthogroups_SingleCopyOrthologues.txt for Orthofinder)."
+                )
+            # Multi-copy detection: comma- or space-separated gene lists.
+            if "," in cell or (" " in cell and "_" not in cell.split(" ")[0]):
+                # Heuristic: if the cell looks like "gene1, gene2" or
+                # "gene1 gene2", reject. We allow a single gene id that
+                # happens to contain spaces (rare but legal).
+                tokens = [t for t in cell.replace(",", " ").split() if t]
+                if len(tokens) > 1:
+                    raise ValueError(
+                        f"Orthologs table {path}: row {r_idx} species {sp!r} "
+                        f"has multiple genes ({len(tokens)}): {cell!r}. "
+                        f".rbh format requires one gene per species per "
+                        f"row. Filter to single-copy orthologs first."
+                    )
+            row_dict[sp] = cell
+        out_rows.append(row_dict)
+
+    return names, pd.DataFrame(out_rows)
+
+
+# ---------------------------------------------------------------------------
+# Join + .rbh emit
+# ---------------------------------------------------------------------------
+
+
+def orthologs_to_rbh(
+    orthologs_path: Path | str,
+    bed_paths: Dict[str, Path | str],
+    species_order: Optional[Sequence[str]] = None,
+    has_header: bool = False,
+    has_orthogroup_id_column: Optional[bool] = None,
+) -> pd.DataFrame:
+    """Join an N-column ortholog table against per-species BED files and
+    return an odp-style `.rbh` DataFrame.
+
+    Args:
+      orthologs_path: path to the tab-separated orthologs table.
+      bed_paths: mapping of species name → path to that species' BED.
+      species_order: if supplied, the species columns of the orthologs
+        table are interpreted in this order (overrides any header row
+        and disables auto-detection of an orthogroup-id column).
+      has_header: True if the orthologs table has a header row.
+      has_orthogroup_id_column: see ``parse_ortholog_table``.
+
+    Returns:
+      A DataFrame with columns
+      ``rbh``, ``gene_group``, then for each species
+      ``<sp>_gene``, ``<sp>_scaf``, ``<sp>_pos``.
+    """
+    species_names, ortho_df = parse_ortholog_table(
+        orthologs_path,
+        species_names=species_order,
+        has_orthogroup_id_column=has_orthogroup_id_column,
+        has_header=has_header,
+    )
+
+    # Every species in the table must have a BED.
+    missing_beds = [s for s in species_names if s not in bed_paths]
+    if missing_beds:
+        raise ValueError(
+            f"BED files missing for species {missing_beds!r}. The orthologs "
+            f"table has columns {species_names!r}; --bed must be supplied "
+            f"for every one."
+        )
+
+    # Load BEDs and build per-species gene-id → (chrom, pos) lookup.
+    sp_lookup: Dict[str, Dict[str, Tuple[str, int]]] = {}
+    for sp in species_names:
+        bed_df = parse_bed(bed_paths[sp])
+        # If a gene id is duplicated in the BED, keep the first; warn.
+        dup_mask = bed_df["gene_id"].duplicated()
+        if dup_mask.any():
+            n_dup = dup_mask.sum()
+            sys.stderr.write(
+                f"orthologs-to-rbh: warning: BED for {sp!r} has {n_dup} "
+                f"duplicate gene_id entries; keeping first occurrence of "
+                f"each.\n"
+            )
+            bed_df = bed_df[~dup_mask].copy()
+        sp_lookup[sp] = dict(zip(bed_df["gene_id"], zip(bed_df["chrom"], bed_df["pos"])))
+
+    # Build the .rbh rows.
+    out_rows: list[dict] = []
+    n_skipped = 0
+    for idx, row in ortho_df.iterrows():
+        new_row: dict = {"rbh": "", "gene_group": "None"}
+        skip = False
+        for sp in species_names:
+            gene_id = row[sp]
+            info = sp_lookup[sp].get(gene_id)
+            if info is None:
+                skip = True
+                break
+            chrom, pos = info
+            new_row[f"{sp}_gene"] = gene_id
+            new_row[f"{sp}_scaf"] = chrom
+            new_row[f"{sp}_pos"] = pos
+        if skip:
+            n_skipped += 1
+            continue
+        out_rows.append(new_row)
+
+    if n_skipped:
+        sys.stderr.write(
+            f"orthologs-to-rbh: skipped {n_skipped} ortholog rows that "
+            f"reference gene ids missing from the BED files.\n"
+        )
+
+    if not out_rows:
+        raise ValueError(
+            "orthologs-to-rbh: zero ortholog rows survived the join with "
+            "the BED files. Check that gene ids match between the orthologs "
+            "table and the BED's fourth column."
+        )
+
+    # Assign sequential rbh ids.
+    for i, r in enumerate(out_rows, start=1):
+        r["rbh"] = f"rbh{i}"
+
+    df = pd.DataFrame(out_rows)
+    # Column order: rbh, gene_group, then triples per species.
+    col_order = ["rbh", "gene_group"]
+    for sp in species_names:
+        col_order += [f"{sp}_gene", f"{sp}_scaf", f"{sp}_pos"]
+    return df[col_order]
+
+
+def write_rbh(df: pd.DataFrame, out_path: Path | str) -> int:
+    """Write an `.rbh` DataFrame to a tab-separated file. Returns the
+    number of rows written."""
+    out_path = Path(out_path)
+    df.to_csv(out_path, sep="\t", index=False)
+    return len(df)

--- a/unittesting/test_cli.py
+++ b/unittesting/test_cli.py
@@ -65,7 +65,7 @@ def test_parser_lists_every_subcommand(cli):
     )
     names = set(subparsers_action.choices.keys())
     expected = set(cli.SNAKEFILES) | {
-        "init", "validate", "version", "orthologs-to-rbh",
+        "init", "validate", "version", "orthologs-to-rbh", "orthofinder-import",
     }
     assert names == expected
 

--- a/unittesting/test_cli.py
+++ b/unittesting/test_cli.py
@@ -64,7 +64,9 @@ def test_parser_lists_every_subcommand(cli):
         a for a in parser._actions if a.dest == "subcommand"
     )
     names = set(subparsers_action.choices.keys())
-    expected = set(cli.SNAKEFILES) | {"init", "validate", "version"}
+    expected = set(cli.SNAKEFILES) | {
+        "init", "validate", "version", "orthologs-to-rbh",
+    }
     assert names == expected
 
 

--- a/unittesting/test_orthofinder_import.py
+++ b/unittesting/test_orthofinder_import.py
@@ -1,0 +1,438 @@
+"""Tests for the Orthofinder importer + multi-copy disambiguation.
+
+Covers:
+- Orthofinder run-dir discovery (Results_*/, Orthogroups/, missing files).
+- Orthogroups.tsv parsing (header, comma+space delimiters, blank cells,
+  ragged rows).
+- partition_single_vs_multi_copy with and without an explicit single-
+  copy list.
+- Anchor-graph construction from a synthetic single-copy backbone.
+- Each multi-copy strategy: skip, longest, most-common-chrom, synteny.
+- min-confidence threshold drops low-score OGs.
+- Top-level orthofinder_to_rbh() against a synthetic 3-species run.
+- CLI subcommand end-to-end.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pandas as pd
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "bin" / "odp"
+
+
+@pytest.fixture(scope="module")
+def ofi(source_dir):
+    import orthofinder_importer
+    return orthofinder_importer
+
+
+@pytest.fixture(scope="module")
+def oti(source_dir):
+    import ortholog_table_importer
+    return ortholog_table_importer
+
+
+# ---------------------------------------------------------------------------
+# Synthetic Orthofinder run
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def orthofinder_synthetic(tmp_path):
+    """Build a synthetic 3-species Orthofinder run plus matching .chrom
+    files. The single-copy backbone establishes that:
+
+      sp1 chr1 partners with sp2 scafA and sp3 ctgX
+      sp1 chr2 partners with sp2 scafB and sp3 ctgY
+
+    Two multi-copy orthogroups are added:
+      OG0000005: sp1=[g5a, g5b], sp2=[x5], sp3=[y5]
+        g5a is on chr1; g5b is on chr2. sp2.x5 is on scafA → expects chr1.
+        So synteny should pick g5a.
+      OG0000006: sp1=[g6], sp2=[x6a, x6b], sp3=[y6]
+        x6a is on scafA; x6b is on scafB. sp1.g6 is on chr2 → expects
+        scafB. Synteny should pick x6b.
+    """
+    root = tmp_path / "Results_Test"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+
+    # Single-copy orthogroups (4 OGs anchoring two chromosome-pair edges).
+    # plus the multi-copy ones at the end.
+    og_tsv = og_dir / "Orthogroups.tsv"
+    og_tsv.write_text(dedent("""\
+        Orthogroup\tsp1\tsp2\tsp3
+        OG0000001\tg1\tx1\ty1
+        OG0000002\tg2\tx2\ty2
+        OG0000003\tg3\tx3\ty3
+        OG0000004\tg4\tx4\ty4
+        OG0000005\tg5a, g5b\tx5\ty5
+        OG0000006\tg6\tx6a, x6b\ty6
+    """))
+
+    # Single-copy list (explicit).
+    (og_dir / "Orthogroups_SingleCopyOrthologues.txt").write_text(
+        "OG0000001\nOG0000002\nOG0000003\nOG0000004\n"
+    )
+
+    # .chrom files for each species.
+    sp1_chrom = tmp_path / "sp1.chrom"
+    sp1_chrom.write_text(dedent("""\
+        g1\tchr1\t+\t100\t200
+        g2\tchr1\t+\t300\t450
+        g3\tchr2\t-\t1000\t1500
+        g4\tchr2\t+\t2000\t2400
+        g5a\tchr1\t+\t500\t600
+        g5b\tchr2\t-\t3000\t3200
+        g6\tchr2\t+\t2500\t2700
+    """))
+    sp2_chrom = tmp_path / "sp2.chrom"
+    sp2_chrom.write_text(dedent("""\
+        x1\tscafA\t+\t50\t150
+        x2\tscafA\t+\t500\t700
+        x3\tscafB\t-\t10\t90
+        x4\tscafB\t+\t200\t400
+        x5\tscafA\t+\t800\t900
+        x6a\tscafA\t-\t1000\t1200
+        x6b\tscafB\t+\t500\t700
+    """))
+    sp3_chrom = tmp_path / "sp3.chrom"
+    sp3_chrom.write_text(dedent("""\
+        y1\tctgX\t+\t1\t10
+        y2\tctgX\t+\t20\t30
+        y3\tctgY\t+\t100\t200
+        y4\tctgY\t+\t300\t400
+        y5\tctgX\t+\t40\t50
+        y6\tctgY\t-\t500\t600
+    """))
+
+    return {
+        "root": root,
+        "og_tsv": og_tsv,
+        "sp1_chrom": sp1_chrom,
+        "sp2_chrom": sp2_chrom,
+        "sp3_chrom": sp3_chrom,
+    }
+
+
+# ---------------------------------------------------------------------------
+# discover_orthofinder_paths
+# ---------------------------------------------------------------------------
+
+
+def test_discover_paths_with_results_root(ofi, orthofinder_synthetic):
+    paths = ofi.discover_orthofinder_paths(orthofinder_synthetic["root"])
+    assert paths.orthogroups_tsv.name == "Orthogroups.tsv"
+    assert paths.single_copy_list is not None
+    assert paths.single_copy_list.name == "Orthogroups_SingleCopyOrthologues.txt"
+
+
+def test_discover_paths_with_orthogroups_subdir(ofi, orthofinder_synthetic):
+    paths = ofi.discover_orthofinder_paths(orthofinder_synthetic["og_tsv"].parent)
+    assert paths.orthogroups_tsv.name == "Orthogroups.tsv"
+
+
+def test_discover_paths_missing_orthogroups_errors(ofi, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match="Orthogroups.tsv"):
+        ofi.discover_orthofinder_paths(empty)
+
+
+# ---------------------------------------------------------------------------
+# parse_orthogroups_tsv
+# ---------------------------------------------------------------------------
+
+
+def test_parse_orthogroups_basic(ofi, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    assert species == ["sp1", "sp2", "sp3"]
+    assert len(df) == 6
+    # OG0000005 multi-copy in sp1
+    og5 = df[df["OG"] == "OG0000005"].iloc[0]
+    assert og5["sp1"] == ["g5a", "g5b"]
+    assert og5["sp2"] == ["x5"]
+
+
+def test_parse_orthogroups_handles_comma_only(ofi, tmp_path):
+    p = tmp_path / "Orthogroups.tsv"
+    p.write_text("Orthogroup\tsp1\tsp2\nOG1\tg1,g1b\tx1\n")
+    species, df = ofi.parse_orthogroups_tsv(p)
+    assert df.iloc[0]["sp1"] == ["g1", "g1b"]
+
+
+def test_parse_orthogroups_handles_empty_cells(ofi, tmp_path):
+    p = tmp_path / "Orthogroups.tsv"
+    p.write_text("Orthogroup\tsp1\tsp2\nOG1\t\tx1\n")
+    species, df = ofi.parse_orthogroups_tsv(p)
+    assert df.iloc[0]["sp1"] == []
+
+
+# ---------------------------------------------------------------------------
+# partition_single_vs_multi_copy
+# ---------------------------------------------------------------------------
+
+
+def test_partition_with_explicit_list(ofi, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    sc_list = ofi.load_single_copy_list(
+        orthofinder_synthetic["root"] / "Orthogroups" /
+        "Orthogroups_SingleCopyOrthologues.txt"
+    )
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, sc_list)
+    assert set(single["OG"]) == {"OG0000001", "OG0000002", "OG0000003", "OG0000004"}
+    assert set(multi["OG"]) == {"OG0000005", "OG0000006"}
+
+
+def test_partition_without_explicit_list(ofi, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    # Auto-partition by cell content should match the explicit list.
+    assert set(single["OG"]) == {"OG0000001", "OG0000002", "OG0000003", "OG0000004"}
+
+
+# ---------------------------------------------------------------------------
+# build_anchor_graph
+# ---------------------------------------------------------------------------
+
+
+def test_build_anchor_graph(ofi, oti, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, _ = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        "sp1": oti.parse_chrom(orthofinder_synthetic["sp1_chrom"]),
+        "sp2": oti.parse_chrom(orthofinder_synthetic["sp2_chrom"]),
+        "sp3": oti.parse_chrom(orthofinder_synthetic["sp3_chrom"]),
+    }
+    g = ofi.build_anchor_graph(single, species, coords)
+    # sp1 chr1 ↔ sp2 scafA should appear twice (OG1 + OG2)
+    assert g.edge[("sp1", "sp2")].get(("chr1", "scafA"), 0) == 2
+    # sp1 chr2 ↔ sp2 scafB twice (OG3 + OG4)
+    assert g.edge[("sp1", "sp2")].get(("chr2", "scafB"), 0) == 2
+    # sp1 chr1 ↔ sp3 ctgX twice
+    assert g.edge[("sp1", "sp3")].get(("chr1", "ctgX"), 0) == 2
+    # Reverse direction populated
+    assert g.edge[("sp2", "sp1")].get(("scafA", "chr1"), 0) == 2
+    # Positions recorded
+    assert len(g.positions["sp1"]["chr1"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Disambiguation strategies
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_skip_drops_all_multi(ofi, oti, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        sp: oti.parse_chrom(orthofinder_synthetic[f"{sp}_chrom"])
+        for sp in species
+    }
+    resolved, audit = ofi.disambiguate_multicopy(
+        multi, species, coords, None, strategy="skip",
+    )
+    assert len(resolved) == 0
+    assert len(audit) == 0
+
+
+def test_strategy_longest_picks_longest_gene(ofi, oti, orthofinder_synthetic):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        sp: oti.parse_chrom(orthofinder_synthetic[f"{sp}_chrom"])
+        for sp in species
+    }
+    resolved, audit = ofi.disambiguate_multicopy(
+        multi, species, coords, None, strategy="longest",
+    )
+    # OG0000005: sp1=[g5a (len 100), g5b (len 200)]. Longest = g5b.
+    og5 = resolved[resolved["OG"] == "OG0000005"].iloc[0]
+    assert og5["sp1"] == ["g5b"]
+    # OG0000006: sp2=[x6a (len 200), x6b (len 200)] — tie. Tie-break by
+    # alphabetic gene id ascending → x6a wins on tie.
+    og6 = resolved[resolved["OG"] == "OG0000006"].iloc[0]
+    assert og6["sp2"][0] in ("x6a", "x6b")
+
+
+def test_strategy_synteny_picks_chromosome_anchored_paralog(
+    ofi, oti, orthofinder_synthetic
+):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        sp: oti.parse_chrom(orthofinder_synthetic[f"{sp}_chrom"])
+        for sp in species
+    }
+    g = ofi.build_anchor_graph(single, species, coords)
+    resolved, audit = ofi.disambiguate_multicopy(
+        multi, species, coords, g, strategy="synteny", min_confidence=1.0,
+    )
+    # OG0000005: sp1's other species are sp2.x5 (scafA) and sp3.y5 (ctgX).
+    # scafA pairs with chr1; ctgX pairs with chr1. So sp1 should pick g5a (chr1).
+    og5 = resolved[resolved["OG"] == "OG0000005"].iloc[0]
+    assert og5["sp1"] == ["g5a"]
+    # OG0000006: sp2 candidates are x6a (scafA) vs x6b (scafB). sp1.g6
+    # is on chr2 and sp3.y6 is on ctgY. chr2 pairs with scafB, ctgY pairs
+    # with scafB. So sp2 should pick x6b.
+    og6 = resolved[resolved["OG"] == "OG0000006"].iloc[0]
+    assert og6["sp2"] == ["x6b"]
+
+
+def test_strategy_most_common_chrom_same_picks_synteny(
+    ofi, oti, orthofinder_synthetic
+):
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        sp: oti.parse_chrom(orthofinder_synthetic[f"{sp}_chrom"])
+        for sp in species
+    }
+    g = ofi.build_anchor_graph(single, species, coords)
+    resolved, _audit = ofi.disambiguate_multicopy(
+        multi, species, coords, g,
+        strategy="most-common-chrom", min_confidence=1.0,
+    )
+    # In this fixture the chromosome vote alone is enough to resolve
+    # both OGs, identical to the synteny strategy.
+    og5 = resolved[resolved["OG"] == "OG0000005"].iloc[0]
+    og6 = resolved[resolved["OG"] == "OG0000006"].iloc[0]
+    assert og5["sp1"] == ["g5a"]
+    assert og6["sp2"] == ["x6b"]
+
+
+def test_min_confidence_drops_low_score(ofi, oti, orthofinder_synthetic):
+    """A very high threshold should drop both multi-copy OGs."""
+    species, df = ofi.parse_orthogroups_tsv(orthofinder_synthetic["og_tsv"])
+    single, multi = ofi.partition_single_vs_multi_copy(df, species, None)
+    coords = {
+        sp: oti.parse_chrom(orthofinder_synthetic[f"{sp}_chrom"])
+        for sp in species
+    }
+    g = ofi.build_anchor_graph(single, species, coords)
+    resolved, _ = ofi.disambiguate_multicopy(
+        multi, species, coords, g,
+        strategy="synteny", min_confidence=1000.0,
+    )
+    assert len(resolved) == 0
+
+
+# ---------------------------------------------------------------------------
+# Top-level orthofinder_to_rbh
+# ---------------------------------------------------------------------------
+
+
+def test_orthofinder_to_rbh_synteny_e2e(ofi, orthofinder_synthetic):
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=orthofinder_synthetic["root"],
+        coord_paths={
+            "sp1": orthofinder_synthetic["sp1_chrom"],
+            "sp2": orthofinder_synthetic["sp2_chrom"],
+            "sp3": orthofinder_synthetic["sp3_chrom"],
+        },
+        strategy="synteny",
+        min_confidence=1.0,
+    )
+    # 4 single-copy + 2 rescued = 6 total
+    assert len(rbh) == 6
+    # Confirm column shape
+    expected_cols = [
+        "rbh", "gene_group",
+        "sp1_gene", "sp1_scaf", "sp1_pos",
+        "sp2_gene", "sp2_scaf", "sp2_pos",
+        "sp3_gene", "sp3_scaf", "sp3_pos",
+    ]
+    assert list(rbh.columns) == expected_cols
+    # Audit covers both multi-copy decisions (sp1 in OG5, sp2 in OG6)
+    assert len(audit) == 2
+
+
+def test_orthofinder_to_rbh_skip_strategy(ofi, orthofinder_synthetic):
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=orthofinder_synthetic["root"],
+        coord_paths={
+            "sp1": orthofinder_synthetic["sp1_chrom"],
+            "sp2": orthofinder_synthetic["sp2_chrom"],
+            "sp3": orthofinder_synthetic["sp3_chrom"],
+        },
+        strategy="skip",
+    )
+    # Only the 4 single-copy OGs.
+    assert len(rbh) == 4
+
+
+def test_orthofinder_to_rbh_missing_coord_for_species_errors(ofi, orthofinder_synthetic):
+    with pytest.raises(ValueError, match="Coord file missing"):
+        ofi.orthofinder_to_rbh(
+            orthofinder_dir=orthofinder_synthetic["root"],
+            coord_paths={
+                "sp1": orthofinder_synthetic["sp1_chrom"],
+                # sp2, sp3 missing
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_cli_orthofinder_import_synteny(tmp_path, orthofinder_synthetic):
+    out = tmp_path / "rbh.tsv"
+    report = tmp_path / "audit.tsv"
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH),
+            "orthofinder-import",
+            "--orthofinder-dir", str(orthofinder_synthetic["root"]),
+            "--chrom", f"sp1={orthofinder_synthetic['sp1_chrom']}",
+            "--chrom", f"sp2={orthofinder_synthetic['sp2_chrom']}",
+            "--chrom", f"sp3={orthofinder_synthetic['sp3_chrom']}",
+            "--multi-copy-strategy", "synteny",
+            "--output", str(out),
+            "--report", str(report),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    body = out.read_text()
+    assert "rbh1" in body
+    # The synteny strategy should rescue g5a (not g5b) and x6b (not x6a).
+    rbh_df = pd.read_csv(out, sep="\t")
+    assert "g5a" in set(rbh_df["sp1_gene"])
+    assert "g5b" not in set(rbh_df["sp1_gene"])
+    assert "x6b" in set(rbh_df["sp2_gene"])
+    assert "x6a" not in set(rbh_df["sp2_gene"])
+    # Audit report exists and has the two disambiguation decisions
+    audit_df = pd.read_csv(report, sep="\t")
+    assert len(audit_df) == 2
+
+
+def test_cli_orthofinder_import_requires_coords(tmp_path, orthofinder_synthetic):
+    out = tmp_path / "rbh.tsv"
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH),
+            "orthofinder-import",
+            "--orthofinder-dir", str(orthofinder_synthetic["root"]),
+            "--output", str(out),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "at least one --chrom or --bed" in result.stderr
+
+
+def test_cli_help_lists_orthofinder_import():
+    result = subprocess.run(
+        [sys.executable, str(CLI_PATH), "--help"],
+        capture_output=True, text=True,
+    )
+    assert "orthofinder-import" in result.stdout

--- a/unittesting/test_orthofinder_import_advanced.py
+++ b/unittesting/test_orthofinder_import_advanced.py
@@ -1,0 +1,836 @@
+"""Advanced tests for the Orthofinder importer.
+
+Coverage focuses on patterns common to ortholog inference test suites:
+
+- **Inparalog handling**: tandem duplicates on the same chromosome.
+- **Gene-family expansions**: orthogroups with 10+ paralogs in a species.
+- **Adversarial ambiguity**: paralogs whose scores tie under one strategy
+  but differ under another.
+- **Sparse backbone**: only a handful of single-copy anchors.
+- **Backbone-free fallback**: zero single-copy OGs, synteny falls back to
+  whatever signal is available without crashing.
+- **NCBI-style identifiers**: gene IDs with pipes, dots, accession-style
+  prefixes (`XP_001.1`, `gi|12345|ref|XP_001.1`).
+- **Compression**: gzipped .chrom and BED inputs.
+- **CRLF line endings** in Orthogroups.tsv (Orthofinder's default).
+- **Mixed --chrom + --bed flags** across species in one invocation.
+- **Round-trip**: build orthogroups from a known .rbh, import, recover.
+- **Audit report shape**: header, row count, columns.
+- **min-confidence threshold boundaries**.
+- **Multi-copy in every species simultaneously** (no within-OG anchor).
+- **Missing gene in coord file** — flagged, not silent.
+- **Strategy comparison**: synteny rescues more OGs than longest on the
+  same fixture, and synteny picks the chromosome-correct paralog where
+  longest picks the chromosome-wrong one.
+"""
+from __future__ import annotations
+
+import gzip
+import subprocess
+import sys
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import pandas as pd
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "bin" / "odp"
+
+
+@pytest.fixture(scope="module")
+def ofi(source_dir):
+    import orthofinder_importer
+    return orthofinder_importer
+
+
+@pytest.fixture(scope="module")
+def oti(source_dir):
+    import ortholog_table_importer
+    return ortholog_table_importer
+
+
+# ===========================================================================
+# Inparalog handling
+# ===========================================================================
+
+
+@pytest.fixture
+def inparalog_fixture(tmp_path):
+    """Two species, with sp1 having a recent tandem duplication
+    (g_dup_a, g_dup_b on the same chromosome adjacent positions).
+    Single-copy backbone has 3 anchors so the chromosome-pair edge is
+    clearly established."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG0000001\ta1\tb1
+        OG0000002\ta2\tb2
+        OG0000003\ta3\tb3
+        OG0000004\tg_dup_a, g_dup_b\tb_dup
+    """))
+
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a1\tchrA\t+\t100\t200
+        a2\tchrA\t+\t1000\t1100
+        a3\tchrA\t+\t2000\t2100
+        g_dup_a\tchrA\t+\t3000\t3500
+        g_dup_b\tchrA\t-\t3600\t3900
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t1\t100
+        b2\tscafX\t+\t200\t300
+        b3\tscafX\t+\t400\t500
+        b_dup\tscafX\t+\t600\t700
+    """))
+    return {"root": root, "sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"}
+
+
+def test_inparalog_synteny_picks_one_deterministically(ofi, inparalog_fixture):
+    """Both tandem duplicates are on the right chromosome — score tie.
+    Tie-break by length, then alphabetic, so the choice is deterministic
+    across runs."""
+    rbh1, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=inparalog_fixture["root"],
+        coord_paths={"sp1": inparalog_fixture["sp1"], "sp2": inparalog_fixture["sp2"]},
+        strategy="synteny",
+    )
+    rbh2, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=inparalog_fixture["root"],
+        coord_paths={"sp1": inparalog_fixture["sp1"], "sp2": inparalog_fixture["sp2"]},
+        strategy="synteny",
+    )
+    # Same fixture, two invocations: same pick both times.
+    pick1 = rbh1[rbh1["rbh"] == rbh1["rbh"].iloc[-1]]["sp1_gene"].iloc[0]
+    pick2 = rbh2[rbh2["rbh"] == rbh2["rbh"].iloc[-1]]["sp1_gene"].iloc[0]
+    assert pick1 == pick2
+    assert pick1 in ("g_dup_a", "g_dup_b")
+
+
+def test_inparalog_longest_picks_longest_tandem(ofi, inparalog_fixture):
+    """g_dup_a is 500bp, g_dup_b is 300bp. 'longest' must pick g_dup_a."""
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=inparalog_fixture["root"],
+        coord_paths={"sp1": inparalog_fixture["sp1"], "sp2": inparalog_fixture["sp2"]},
+        strategy="longest",
+    )
+    multi_row = rbh[rbh["sp1_gene"].isin(["g_dup_a", "g_dup_b"])].iloc[0]
+    assert multi_row["sp1_gene"] == "g_dup_a"
+
+
+# ===========================================================================
+# Gene-family expansion (large multi-copy)
+# ===========================================================================
+
+
+@pytest.fixture
+def large_family_fixture(tmp_path):
+    """One orthogroup with 20 paralogs in sp1. Only 1 of them is on the
+    syntenic chromosome; the rest are on unrelated chromosomes."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+
+    # 4 single-copy anchors establishing chrA ↔ scafX
+    sc_lines = [
+        f"OG{i:07d}\ta{i}\tb{i}" for i in range(1, 5)
+    ]
+    # Large multi-copy orthogroup
+    paralogs = [f"para_{i}" for i in range(20)]
+    multi_row = f"OG0000005\t{', '.join(paralogs)}\tb_target"
+    (og_dir / "Orthogroups.tsv").write_text(
+        "Orthogroup\tsp1\tsp2\n" + "\n".join(sc_lines + [multi_row]) + "\n"
+    )
+
+    sp1_lines = [f"a{i}\tchrA\t+\t{i * 1000}\t{i * 1000 + 100}" for i in range(1, 5)]
+    # The "true" paralog is on chrA; the rest are on chrB-chrT
+    sp1_lines.append(f"para_0\tchrA\t+\t50000\t50500")  # on syntenic chrom
+    for i in range(1, 20):
+        sp1_lines.append(f"para_{i}\tchr{chr(ord('B') + (i - 1) % 19)}\t+\t100\t200")
+    (tmp_path / "sp1.chrom").write_text("\n".join(sp1_lines) + "\n")
+
+    sp2_lines = [f"b{i}\tscafX\t+\t{i * 1000}\t{i * 1000 + 100}" for i in range(1, 5)]
+    sp2_lines.append("b_target\tscafX\t+\t60000\t60500")
+    (tmp_path / "sp2.chrom").write_text("\n".join(sp2_lines) + "\n")
+
+    return {"root": root, "sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"}
+
+
+def test_large_gene_family_synteny_picks_syntenic_paralog(ofi, large_family_fixture):
+    """With 1 syntenic + 19 non-syntenic paralogs, synteny must pick the
+    syntenic one (para_0)."""
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=large_family_fixture["root"],
+        coord_paths={"sp1": large_family_fixture["sp1"], "sp2": large_family_fixture["sp2"]},
+        strategy="synteny",
+    )
+    multi_row = rbh[~rbh["sp1_gene"].str.match(r"^a\d+$")].iloc[0]
+    assert multi_row["sp1_gene"] == "para_0"
+    # Audit should record all 20 candidates considered
+    multi_audit = [d for d in audit if d.og == "OG0000005"][0]
+    assert multi_audit.n_candidates == 20
+
+
+def test_large_gene_family_longest_likely_picks_wrong(ofi, large_family_fixture):
+    """All paralogs are the same length in this fixture, so 'longest'
+    falls back to alphabetic tie-break — para_0 wins by accident here.
+    Still, the *reasoning* is different — confirm via the audit."""
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=large_family_fixture["root"],
+        coord_paths={"sp1": large_family_fixture["sp1"], "sp2": large_family_fixture["sp2"]},
+        strategy="longest",
+    )
+    multi_audit = [d for d in audit if d.og == "OG0000005"][0]
+    assert "length=" in multi_audit.reason
+
+
+# ===========================================================================
+# Sparse backbone
+# ===========================================================================
+
+
+@pytest.fixture
+def sparse_backbone(tmp_path):
+    """Only ONE single-copy orthogroup to anchor the chromosome map."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG0000001\ta1\tb1
+        OG0000002\ta2, a2b\tb2
+    """))
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a1\tchrA\t+\t1\t100
+        a2\tchrA\t+\t200\t300
+        a2b\tchrB\t+\t1\t100
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t1\t100
+        b2\tscafX\t+\t200\t300
+    """))
+    return {"root": root, "sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"}
+
+
+def test_sparse_backbone_one_anchor_still_resolves(ofi, sparse_backbone):
+    """With just one anchor (chrA ↔ scafX, weight 1), synteny should
+    still pick a2 (on chrA) over a2b (on chrB)."""
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=sparse_backbone["root"],
+        coord_paths={"sp1": sparse_backbone["sp1"], "sp2": sparse_backbone["sp2"]},
+        strategy="synteny",
+        min_confidence=1.0,
+    )
+    multi = rbh[rbh["sp1_gene"].isin(["a2", "a2b"])].iloc[0]
+    assert multi["sp1_gene"] == "a2"
+
+
+# ===========================================================================
+# Backbone-empty fallback
+# ===========================================================================
+
+
+def test_backbone_empty_synteny_degenerates_safely(ofi, tmp_path):
+    """No single-copy OGs at all. Synteny has nothing to anchor against.
+    The function should not crash; it should produce an empty rbh and a
+    multi-copy audit explaining why nothing was rescued."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG0000001\ta1, a1b\tb1, b1b
+    """))
+    (tmp_path / "sp1.chrom").write_text(
+        "a1\tchrA\t+\t1\t100\na1b\tchrB\t+\t1\t100\n"
+    )
+    (tmp_path / "sp2.chrom").write_text(
+        "b1\tscafX\t+\t1\t100\nb1b\tscafY\t+\t1\t100\n"
+    )
+
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+        min_confidence=1.0,
+    )
+    # No backbone → no chromosome-pair edges → all scores 0 → below
+    # min-confidence → no rescue.
+    assert len(rbh) == 0
+
+
+# ===========================================================================
+# NCBI-style gene identifiers
+# ===========================================================================
+
+
+def test_ncbi_style_gene_ids_round_trip(ofi, oti, tmp_path):
+    """Gene IDs with dots, pipes, underscores, accession prefixes."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG0000001\tXP_001234.1\tNP_005678.2
+        OG0000002\tgi|12345|ref|XP_007890.3|\tNP_111222.1
+    """))
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        XP_001234.1\tNC_054740.1\t+\t1\t100
+        gi|12345|ref|XP_007890.3|\tNC_054740.1\t+\t200\t300
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        NP_005678.2\tNC_061156.1\t+\t1\t100
+        NP_111222.1\tNC_061156.1\t+\t200\t300
+    """))
+
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+    )
+    assert len(rbh) == 2
+    assert "XP_001234.1" in set(rbh["sp1_gene"])
+    assert "gi|12345|ref|XP_007890.3|" in set(rbh["sp1_gene"])
+
+
+# ===========================================================================
+# Compression: gzipped .chrom and BED
+# ===========================================================================
+
+
+def test_gzipped_chrom_input(ofi, tmp_path):
+    """A .chrom.gz file should parse identically to its plain text twin."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(
+        "Orthogroup\tsp1\tsp2\nOG0000001\ta1\tb1\n"
+    )
+
+    # Plain text + gzipped twin
+    plain = tmp_path / "sp1.chrom"
+    plain.write_text("a1\tchrA\t+\t1\t100\n")
+    gz = tmp_path / "sp1.chrom.gz"
+    with gzip.open(gz, "wt") as fh:
+        fh.write("a1\tchrA\t+\t1\t100\n")
+
+    (tmp_path / "sp2.chrom").write_text("b1\tscafX\t+\t1\t100\n")
+
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": gz, "sp2": tmp_path / "sp2.chrom"},
+        strategy="skip",  # only one OG, no multi-copy
+    )
+    assert len(rbh) == 1
+    assert rbh.iloc[0]["sp1_gene"] == "a1"
+    assert rbh.iloc[0]["sp1_scaf"] == "chrA"
+
+
+def test_gzipped_bed_input(oti, tmp_path):
+    plain_bed = tmp_path / "sp1.bed"
+    plain_bed.write_text("chr1\t1\t100\tg1\n")
+    gz_bed = tmp_path / "sp1.bed.gz"
+    with gzip.open(gz_bed, "wt") as fh:
+        fh.write("chr1\t1\t100\tg1\n")
+    plain_df = oti.parse_bed(plain_bed)
+    gz_df = oti.parse_bed(gz_bed)
+    pd.testing.assert_frame_equal(plain_df.reset_index(drop=True),
+                                   gz_df.reset_index(drop=True))
+
+
+# ===========================================================================
+# CRLF in Orthogroups.tsv
+# ===========================================================================
+
+
+def test_orthogroups_with_crlf_line_endings(ofi, tmp_path):
+    """Orthofinder emits CRLF by default; the parser must normalise."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    # Use bytes-level write so the \r\n stays exactly as written.
+    (og_dir / "Orthogroups.tsv").write_bytes(
+        b"Orthogroup\tsp1\tsp2\r\n"
+        b"OG0000001\ta1\tb1\r\n"
+        b"OG0000002\ta2\tb2\r\n"
+    )
+    species, df = ofi.parse_orthogroups_tsv(og_dir / "Orthogroups.tsv")
+    assert species == ["sp1", "sp2"]
+    assert len(df) == 2
+    # No stray \r should leak into gene IDs
+    assert "\r" not in df.iloc[0]["sp2"][0]
+
+
+# ===========================================================================
+# Mixed --chrom and --bed across species
+# ===========================================================================
+
+
+def test_mixed_chrom_and_bed_flags(tmp_path):
+    """Some species via --chrom, others via --bed, in the same run."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(
+        "Orthogroup\tsp1\tsp2\nOG0000001\ta1\tb1\n"
+    )
+    sp1_chrom = tmp_path / "sp1.chrom"
+    sp1_chrom.write_text("a1\tchrA\t+\t1\t100\n")
+    sp2_bed = tmp_path / "sp2.bed"
+    sp2_bed.write_text("scafX\t1\t100\tb1\n")
+
+    out = tmp_path / "rbh.tsv"
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH), "orthofinder-import",
+            "--orthofinder-dir", str(root),
+            "--chrom", f"sp1={sp1_chrom}",
+            "--bed", f"sp2={sp2_bed}",
+            "--multi-copy-strategy", "skip",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    rbh = pd.read_csv(out, sep="\t")
+    assert rbh.iloc[0]["sp1_scaf"] == "chrA"
+    assert rbh.iloc[0]["sp2_scaf"] == "scafX"
+
+
+# ===========================================================================
+# Round-trip: .rbh -> orthogroups -> orthofinder-import -> .rbh
+# ===========================================================================
+
+
+def test_round_trip_from_rbh(ofi, oti, tmp_path):
+    """Take a known .rbh, synthesise an Orthofinder-style table from it,
+    re-import, confirm the original ortholog tuples are recovered."""
+    # Synthetic .rbh-shaped table
+    original_pairs = [
+        ("g1", "x1"),
+        ("g2", "x2"),
+        ("g3", "x3"),
+    ]
+    sp1_lines, sp2_lines = [], []
+    for i, (g, x) in enumerate(original_pairs):
+        sp1_lines.append(f"{g}\tchrA\t+\t{(i+1) * 1000}\t{(i+1) * 1000 + 100}")
+        sp2_lines.append(f"{x}\tscafX\t+\t{(i+1) * 1000}\t{(i+1) * 1000 + 100}")
+    (tmp_path / "sp1.chrom").write_text("\n".join(sp1_lines) + "\n")
+    (tmp_path / "sp2.chrom").write_text("\n".join(sp2_lines) + "\n")
+
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    og_lines = "Orthogroup\tsp1\tsp2\n"
+    for i, (g, x) in enumerate(original_pairs):
+        og_lines += f"OG{i+1:07d}\t{g}\t{x}\n"
+    (og_dir / "Orthogroups.tsv").write_text(og_lines)
+
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+    )
+
+    recovered_pairs = list(zip(rbh["sp1_gene"], rbh["sp2_gene"]))
+    assert set(recovered_pairs) == set(original_pairs)
+
+
+# ===========================================================================
+# Audit report shape
+# ===========================================================================
+
+
+def test_audit_report_columns(ofi, orthofinder_synthetic, tmp_path):
+    """The audit TSV must have a fixed column set so downstream tools can
+    parse it reliably."""
+    # Reuse the fixture from the basic test module.
+    from unittesting.test_orthofinder_import import orthofinder_synthetic as _ofs  # noqa: F401
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=orthofinder_synthetic["root"],
+        coord_paths={
+            "sp1": orthofinder_synthetic["sp1_chrom"],
+            "sp2": orthofinder_synthetic["sp2_chrom"],
+            "sp3": orthofinder_synthetic["sp3_chrom"],
+        },
+        strategy="synteny",
+    )
+    report = tmp_path / "audit.tsv"
+    ofi.write_audit_report(audit, report)
+    df = pd.read_csv(report, sep="\t")
+    expected_cols = [
+        "OG", "species", "strategy", "n_candidates",
+        "picked_gene", "picked_score",
+        "second_best_gene", "second_best_score", "reason",
+    ]
+    assert list(df.columns) == expected_cols
+
+
+def test_audit_report_empty_when_no_multi_copy(ofi, tmp_path):
+    """Skip strategy on a single-copy-only run: audit is empty but the
+    file still has a header row."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(
+        "Orthogroup\tsp1\tsp2\nOG1\tg1\tx1\n"
+    )
+    (tmp_path / "sp1.chrom").write_text("g1\tchrA\t+\t1\t100\n")
+    (tmp_path / "sp2.chrom").write_text("x1\tscafX\t+\t1\t100\n")
+
+    _, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="skip",
+    )
+    report = tmp_path / "audit.tsv"
+    n = ofi.write_audit_report(audit, report)
+    assert n == 0
+    body = report.read_text()
+    assert body.split("\n")[0].startswith("OG\tspecies\t")
+
+
+# ===========================================================================
+# min-confidence boundary
+# ===========================================================================
+
+
+def test_min_confidence_zero_keeps_everything(ofi, tmp_path):
+    """min-confidence=0 should keep even score-0 picks (anything beats
+    skipping)."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG1\ta1\tb1
+        OG2\ta1_dup, a2_dup\tb2
+    """))
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a1\tchrA\t+\t1\t100
+        a1_dup\tchrZ\t+\t1\t100
+        a2_dup\tchrZ\t+\t200\t300
+    """))
+    # sp2 b1 on scafX, b2 on scafY — chrA↔scafX edge has weight 1, no
+    # edge between chrZ and scafY → chrom_score = 0 for both candidates.
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t1\t100
+        b2\tscafY\t+\t1\t100
+    """))
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+        min_confidence=0.0,
+    )
+    # Both OGs should survive even though OG2's chrom_score is 0.
+    assert len(rbh) == 2
+
+
+# ===========================================================================
+# Multi-copy in every species simultaneously
+# ===========================================================================
+
+
+def test_multi_copy_in_every_species(ofi, tmp_path):
+    """OG has multiple candidates in both species. No within-OG anchor.
+    Synteny must score each pairing against the single-copy backbone."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    # 3 single-copy anchors establishing chrA ↔ scafX
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG1\ta1\tb1
+        OG2\ta2\tb2
+        OG3\ta3\tb3
+        OG_AMB\tcand_correct_chrA, cand_wrong_chrB\ttarget_correct_scafX, target_wrong_scafY
+    """))
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a1\tchrA\t+\t100\t200
+        a2\tchrA\t+\t1000\t1100
+        a3\tchrA\t+\t2000\t2100
+        cand_correct_chrA\tchrA\t+\t3000\t3100
+        cand_wrong_chrB\tchrB\t+\t500\t600
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t100\t200
+        b2\tscafX\t+\t1000\t1100
+        b3\tscafX\t+\t2000\t2100
+        target_correct_scafX\tscafX\t+\t3000\t3100
+        target_wrong_scafY\tscafY\t+\t500\t600
+    """))
+    rbh, audit = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+    )
+    # OG_AMB should survive with the correct pairing.
+    amb = rbh[rbh["rbh"] == rbh["rbh"].iloc[-1]].iloc[0]
+    # The first multi-copy species gets resolved first; its pick anchors
+    # the second species. Either ordering should land on the chrA/scafX
+    # pair because both anchor toward chrA↔scafX edges.
+    assert amb["sp1_gene"] == "cand_correct_chrA"
+    assert amb["sp2_gene"] == "target_correct_scafX"
+
+
+# ===========================================================================
+# Missing gene in coord file
+# ===========================================================================
+
+
+def test_missing_gene_in_chrom_drops_og(ofi, tmp_path):
+    """If a gene listed in Orthogroups.tsv has no entry in the .chrom
+    file, that orthogroup must be dropped from the output (and the audit
+    should record the failure)."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG1\ta1\tb1
+        OG2\tnot_in_chrom\tb2
+    """))
+    (tmp_path / "sp1.chrom").write_text("a1\tchrA\t+\t1\t100\n")
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t1\t100
+        b2\tscafX\t+\t200\t300
+    """))
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+    )
+    # Only OG1 survives; OG2's sp1 gene wasn't found.
+    assert set(rbh["sp1_gene"]) == {"a1"}
+
+
+# ===========================================================================
+# Strategy comparison: synteny rescues more than longest where it counts
+# ===========================================================================
+
+
+@pytest.fixture
+def strategy_divergence_fixture(tmp_path):
+    """Constructed so that 'longest' picks the chromosome-wrong paralog
+    and 'synteny' picks the chromosome-right one."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG1\ta1\tb1
+        OG2\ta2\tb2
+        OG3\ta3\tb3
+        OG_TEST\tshort_correct, long_wrong\tb_target
+    """))
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a1\tchrA\t+\t100\t200
+        a2\tchrA\t+\t1000\t1100
+        a3\tchrA\t+\t2000\t2100
+        short_correct\tchrA\t+\t3000\t3100
+        long_wrong\tchrZ\t+\t1\t100000
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b1\tscafX\t+\t100\t200
+        b2\tscafX\t+\t1000\t1100
+        b3\tscafX\t+\t2000\t2100
+        b_target\tscafX\t+\t3000\t3100
+    """))
+    return {"root": root, "sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"}
+
+
+def test_synteny_picks_short_correct(ofi, strategy_divergence_fixture):
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=strategy_divergence_fixture["root"],
+        coord_paths={"sp1": strategy_divergence_fixture["sp1"], "sp2": strategy_divergence_fixture["sp2"]},
+        strategy="synteny",
+    )
+    test_row = rbh[rbh["sp1_gene"].isin(["short_correct", "long_wrong"])].iloc[0]
+    assert test_row["sp1_gene"] == "short_correct"
+
+
+def test_longest_picks_long_wrong(ofi, strategy_divergence_fixture):
+    rbh, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=strategy_divergence_fixture["root"],
+        coord_paths={"sp1": strategy_divergence_fixture["sp1"], "sp2": strategy_divergence_fixture["sp2"]},
+        strategy="longest",
+    )
+    test_row = rbh[rbh["sp1_gene"].isin(["short_correct", "long_wrong"])].iloc[0]
+    assert test_row["sp1_gene"] == "long_wrong"
+
+
+# ===========================================================================
+# synteny vs most-common-chrom: position breaks chromosome ties
+# ===========================================================================
+
+
+def test_synteny_proximity_breaks_chromosome_ties(ofi, tmp_path):
+    """Two paralogs on the same chromosome. most-common-chrom scores them
+    identically. synteny tiebreaks by proximity to the single-copy
+    anchors on that chromosome."""
+    root = tmp_path / "Results"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG1\ta_anchor\tb_anchor
+        OG2\ta_near, a_far\tb_target
+    """))
+    # Anchor at pos 50_000. a_near is 1 Mbp away (pos ~51_000_000);
+    # a_far is 50 Mbp away (pos ~100_000_000). Both on chrA.
+    (tmp_path / "sp1.chrom").write_text(dedent("""\
+        a_anchor\tchrA\t+\t49000\t51000
+        a_near\tchrA\t+\t51000000\t51001000
+        a_far\tchrA\t+\t100000000\t100001000
+    """))
+    (tmp_path / "sp2.chrom").write_text(dedent("""\
+        b_anchor\tscafX\t+\t1\t100
+        b_target\tscafX\t+\t200\t300
+    """))
+    rbh_synteny, _ = ofi.orthofinder_to_rbh(
+        orthofinder_dir=root,
+        coord_paths={"sp1": tmp_path / "sp1.chrom", "sp2": tmp_path / "sp2.chrom"},
+        strategy="synteny",
+    )
+    multi = rbh_synteny[rbh_synteny["sp1_gene"].isin(["a_near", "a_far"])].iloc[0]
+    assert multi["sp1_gene"] == "a_near"
+
+
+# ===========================================================================
+# Performance regression (loose bound)
+# ===========================================================================
+
+
+def test_orthogroups_parsing_handles_10k_rows_quickly(ofi, tmp_path):
+    """Synthetic 10k-OG Orthogroups.tsv should parse in well under 5
+    seconds."""
+    p = tmp_path / "big.tsv"
+    lines = ["Orthogroup\tsp1\tsp2"]
+    for i in range(10_000):
+        lines.append(f"OG{i:07d}\tg{i}\tx{i}")
+    p.write_text("\n".join(lines) + "\n")
+
+    start = time.perf_counter()
+    species, df = ofi.parse_orthogroups_tsv(p)
+    elapsed = time.perf_counter() - start
+    assert len(df) == 10_000
+    assert species == ["sp1", "sp2"]
+    assert elapsed < 5.0, f"parse took {elapsed:.2f}s (>5s budget)"
+
+
+# ===========================================================================
+# Strategy: skip + longest + synteny exit codes are all 0
+# ===========================================================================
+
+
+@pytest.mark.parametrize("strategy", ["skip", "longest", "most-common-chrom", "synteny"])
+def test_cli_every_strategy_produces_output(strategy, tmp_path, orthofinder_synthetic):
+    out = tmp_path / "rbh.tsv"
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH), "orthofinder-import",
+            "--orthofinder-dir", str(orthofinder_synthetic["root"]),
+            "--chrom", f"sp1={orthofinder_synthetic['sp1_chrom']}",
+            "--chrom", f"sp2={orthofinder_synthetic['sp2_chrom']}",
+            "--chrom", f"sp3={orthofinder_synthetic['sp3_chrom']}",
+            "--multi-copy-strategy", strategy,
+            "--output", str(out),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"strategy={strategy}: {result.stderr}"
+    rbh = pd.read_csv(out, sep="\t")
+    # Single-copy backbone (4 OGs) must always survive.
+    assert len(rbh) >= 4
+
+
+# Bring the basic fixture into scope here so the strategy-comparison
+# CLI parametrize can use it.
+@pytest.fixture
+def orthofinder_synthetic(tmp_path):
+    root = tmp_path / "Results_Test"
+    og_dir = root / "Orthogroups"
+    og_dir.mkdir(parents=True)
+    (og_dir / "Orthogroups.tsv").write_text(dedent("""\
+        Orthogroup\tsp1\tsp2\tsp3
+        OG0000001\tg1\tx1\ty1
+        OG0000002\tg2\tx2\ty2
+        OG0000003\tg3\tx3\ty3
+        OG0000004\tg4\tx4\ty4
+        OG0000005\tg5a, g5b\tx5\ty5
+        OG0000006\tg6\tx6a, x6b\ty6
+    """))
+    sp1 = tmp_path / "sp1.chrom"
+    sp1.write_text(dedent("""\
+        g1\tchr1\t+\t100\t200
+        g2\tchr1\t+\t300\t450
+        g3\tchr2\t-\t1000\t1500
+        g4\tchr2\t+\t2000\t2400
+        g5a\tchr1\t+\t500\t600
+        g5b\tchr2\t-\t3000\t3200
+        g6\tchr2\t+\t2500\t2700
+    """))
+    sp2 = tmp_path / "sp2.chrom"
+    sp2.write_text(dedent("""\
+        x1\tscafA\t+\t50\t150
+        x2\tscafA\t+\t500\t700
+        x3\tscafB\t-\t10\t90
+        x4\tscafB\t+\t200\t400
+        x5\tscafA\t+\t800\t900
+        x6a\tscafA\t-\t1000\t1200
+        x6b\tscafB\t+\t500\t700
+    """))
+    sp3 = tmp_path / "sp3.chrom"
+    sp3.write_text(dedent("""\
+        y1\tctgX\t+\t1\t10
+        y2\tctgX\t+\t20\t30
+        y3\tctgY\t+\t100\t200
+        y4\tctgY\t+\t300\t400
+        y5\tctgX\t+\t40\t50
+        y6\tctgY\t-\t500\t600
+    """))
+    return {
+        "root": root, "sp1_chrom": sp1, "sp2_chrom": sp2, "sp3_chrom": sp3,
+    }
+
+
+# ===========================================================================
+# CLI: rejects unknown strategy
+# ===========================================================================
+
+
+def test_cli_rejects_unknown_strategy(tmp_path, orthofinder_synthetic):
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH), "orthofinder-import",
+            "--orthofinder-dir", str(orthofinder_synthetic["root"]),
+            "--chrom", f"sp1={orthofinder_synthetic['sp1_chrom']}",
+            "--chrom", f"sp2={orthofinder_synthetic['sp2_chrom']}",
+            "--chrom", f"sp3={orthofinder_synthetic['sp3_chrom']}",
+            "--multi-copy-strategy", "tree-based",
+            "--output", str(tmp_path / "out.tsv"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "invalid choice" in result.stderr
+
+
+def test_cli_orthofinder_dir_missing(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH), "orthofinder-import",
+            "--orthofinder-dir", "/nonexistent/path",
+            "--chrom", f"sp1={tmp_path}/sp1.chrom",
+            "--output", str(tmp_path / "out.tsv"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "does not exist" in result.stderr.lower()

--- a/unittesting/test_orthologs_to_rbh.py
+++ b/unittesting/test_orthologs_to_rbh.py
@@ -1,0 +1,431 @@
+"""Tests for the orthologs-to-rbh import path.
+
+Covers:
+- BED parsing (4-column, 6-column, CRLF, blank lines, bad rows).
+- Orthologs-table parsing (with and without orthogroup-id column,
+  auto-detection, header row, --species-order override, multi-copy
+  rejection, empty cells, mismatched column counts).
+- Join + .rbh emission (column order, sequential rbh ids, midpoint
+  position, skipped rows when gene ids aren't in the BED, duplicate
+  gene-id handling, full N-species path).
+- The CLI subcommand end-to-end via subprocess.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "bin" / "odp"
+
+
+@pytest.fixture(scope="module")
+def importer(source_dir):
+    """Import the importer module via the source_dir fixture (which inserts
+    source/ onto sys.path)."""
+    import ortholog_table_importer
+    return ortholog_table_importer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def two_species_bed_pair(tmp_path):
+    sp1 = tmp_path / "sp1.bed"
+    sp1.write_text(dedent("""\
+        chr1\t100\t200\tg1
+        chr1\t300\t450\tg2
+        chr2\t1000\t1500\tg3
+        chr2\t2000\t2400\tg4
+    """))
+    sp2 = tmp_path / "sp2.bed"
+    sp2.write_text(dedent("""\
+        scafA\t50\t150\tx1
+        scafA\t500\t700\tx2
+        scafB\t10\t90\tx3
+        scafB\t200\t400\tx4
+    """))
+    return sp1, sp2
+
+
+@pytest.fixture
+def two_col_orthologs(tmp_path):
+    p = tmp_path / "pairs.tsv"
+    p.write_text(dedent("""\
+        g1\tx1
+        g2\tx2
+        g3\tx3
+        g4\tx4
+    """))
+    return p
+
+
+@pytest.fixture
+def orthofinder_style(tmp_path):
+    """Orthofinder-style: leading orthogroup-id column, then per-species
+    gene columns. Header row included."""
+    p = tmp_path / "Orthogroups.tsv"
+    p.write_text(dedent("""\
+        Orthogroup\tsp1\tsp2
+        OG0000001\tg1\tx1
+        OG0000002\tg2\tx2
+        OG0000003\tg3\tx3
+        OG0000004\tg4\tx4
+    """))
+    return p
+
+
+@pytest.fixture
+def orthofinder_no_header(tmp_path):
+    """Same as Orthofinder but without the header row."""
+    p = tmp_path / "Orthogroups.tsv"
+    p.write_text(dedent("""\
+        OG0000001\tg1\tx1
+        OG0000002\tg2\tx2
+        OG0000003\tg3\tx3
+        OG0000004\tg4\tx4
+    """))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# BED parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bed_basic(importer, two_species_bed_pair):
+    sp1, _ = two_species_bed_pair
+    df = importer.parse_bed(sp1)
+    assert len(df) == 4
+    assert list(df.columns) == ["chrom", "start", "end", "gene_id", "pos"]
+    assert df.loc[0, "gene_id"] == "g1"
+    assert df.loc[0, "pos"] == (100 + 200) // 2
+
+
+def test_parse_bed_extra_columns_ignored(importer, tmp_path):
+    p = tmp_path / "extra.bed"
+    p.write_text("chr1\t10\t20\tg1\t.\t+\tfoo\n")
+    df = importer.parse_bed(p)
+    assert len(df) == 1
+    assert df.loc[0, "gene_id"] == "g1"
+
+
+def test_parse_bed_crlf_endings(importer, tmp_path):
+    p = tmp_path / "crlf.bed"
+    p.write_text("chr1\t10\t20\tg1\r\nchr1\t30\t40\tg2\r\n")
+    df = importer.parse_bed(p)
+    assert len(df) == 2
+    assert df.loc[0, "gene_id"] == "g1"
+
+
+def test_parse_bed_blank_lines_skipped(importer, tmp_path):
+    p = tmp_path / "blanks.bed"
+    p.write_text("\n\nchr1\t10\t20\tg1\n\nchr1\t30\t40\tg2\n\n")
+    df = importer.parse_bed(p)
+    assert len(df) == 2
+
+
+def test_parse_bed_too_few_columns_errors(importer, tmp_path):
+    p = tmp_path / "bad.bed"
+    p.write_text("chr1\t10\t20\n")
+    with pytest.raises(ValueError, match="at least 4 tab"):
+        importer.parse_bed(p)
+
+
+def test_parse_bed_non_integer_coords_errors(importer, tmp_path):
+    p = tmp_path / "bad.bed"
+    p.write_text("chr1\tNOT_AN_INT\t20\tg1\n")
+    with pytest.raises(ValueError, match="must be integers"):
+        importer.parse_bed(p)
+
+
+def test_parse_bed_empty_file_errors(importer, tmp_path):
+    p = tmp_path / "empty.bed"
+    p.write_text("")
+    with pytest.raises(ValueError, match="empty or has no parseable"):
+        importer.parse_bed(p)
+
+
+# ---------------------------------------------------------------------------
+# Orthologs-table parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_two_col_no_header_no_og(importer, two_col_orthologs):
+    names, df = importer.parse_ortholog_table(two_col_orthologs)
+    # Auto-detect: first column doesn't match orthogroup id pattern, so
+    # treated as a gene column.
+    assert names == ["sp1", "sp2"]
+    assert len(df) == 4
+    assert df.loc[0, "sp1"] == "g1"
+    assert df.loc[0, "sp2"] == "x1"
+
+
+def test_parse_orthofinder_style_auto_detects_og_column(importer, orthofinder_no_header):
+    names, df = importer.parse_ortholog_table(orthofinder_no_header)
+    # First column values match ^[A-Za-z]+\d+$, so auto-detected as OG ids.
+    # Species names default to sp1/sp2.
+    assert names == ["sp1", "sp2"]
+    assert len(df) == 4
+    assert df.loc[0, "sp1"] == "g1"
+    assert df.loc[0, "sp2"] == "x1"
+
+
+def test_parse_orthofinder_style_with_header(importer, orthofinder_style):
+    names, df = importer.parse_ortholog_table(
+        orthofinder_style,
+        has_header=True,
+    )
+    assert names == ["sp1", "sp2"]
+    assert len(df) == 4
+
+
+def test_parse_species_order_overrides_header(importer, orthofinder_style):
+    names, df = importer.parse_ortholog_table(
+        orthofinder_style,
+        species_names=["A", "B"],
+        has_header=True,
+        has_orthogroup_id_column=True,
+    )
+    assert names == ["A", "B"]
+    assert "A" in df.columns
+    assert "B" in df.columns
+
+
+def test_parse_rejects_multi_copy_row(importer, tmp_path):
+    p = tmp_path / "multi.tsv"
+    p.write_text("g1\tx1,x1b\n")
+    with pytest.raises(ValueError, match="multiple genes"):
+        importer.parse_ortholog_table(p, species_names=["sp1", "sp2"])
+
+
+def test_parse_rejects_empty_cell(importer, tmp_path):
+    p = tmp_path / "empty_cell.tsv"
+    p.write_text("g1\t\ng2\tx2\n")
+    with pytest.raises(ValueError, match="empty cell"):
+        importer.parse_ortholog_table(p, species_names=["sp1", "sp2"])
+
+
+def test_parse_rejects_inconsistent_column_count(importer, tmp_path):
+    p = tmp_path / "bad.tsv"
+    p.write_text("g1\tx1\ng2\tx2\tEXTRA\n")
+    with pytest.raises(ValueError, match="inconsistent column count"):
+        importer.parse_ortholog_table(p, species_names=["sp1", "sp2"])
+
+
+def test_parse_strips_crlf(importer, tmp_path):
+    p = tmp_path / "crlf.tsv"
+    p.write_text("g1\tx1\r\ng2\tx2\r\n")
+    names, df = importer.parse_ortholog_table(
+        p, species_names=["sp1", "sp2"],
+    )
+    assert len(df) == 2
+    # No \r should leak through.
+    assert "\r" not in df.loc[0, "sp2"]
+
+
+def test_parse_species_names_count_mismatch_errors(importer, two_col_orthologs):
+    with pytest.raises(ValueError, match="3 entries but the table has 2"):
+        importer.parse_ortholog_table(
+            two_col_orthologs, species_names=["a", "b", "c"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Join + .rbh emission
+# ---------------------------------------------------------------------------
+
+
+def test_orthologs_to_rbh_two_species(
+    importer, two_species_bed_pair, two_col_orthologs
+):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    df = importer.orthologs_to_rbh(
+        orthologs_path=two_col_orthologs,
+        bed_paths={"sp1": sp1_bed, "sp2": sp2_bed},
+        species_order=["sp1", "sp2"],
+    )
+    assert len(df) == 4
+    expected_cols = [
+        "rbh", "gene_group",
+        "sp1_gene", "sp1_scaf", "sp1_pos",
+        "sp2_gene", "sp2_scaf", "sp2_pos",
+    ]
+    assert list(df.columns) == expected_cols
+    # First row: g1 ↔ x1
+    row = df.iloc[0]
+    assert row["rbh"] == "rbh1"
+    assert row["gene_group"] == "None"
+    assert row["sp1_gene"] == "g1"
+    assert row["sp1_scaf"] == "chr1"
+    assert row["sp1_pos"] == (100 + 200) // 2
+    assert row["sp2_gene"] == "x1"
+    assert row["sp2_scaf"] == "scafA"
+    assert row["sp2_pos"] == (50 + 150) // 2
+
+
+def test_orthologs_to_rbh_skips_missing_bed_genes(
+    importer, two_species_bed_pair, tmp_path, capsys
+):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    p = tmp_path / "pairs.tsv"
+    # g1 is in sp1.bed, MISSING is not — that row must be skipped.
+    p.write_text("g1\tx1\nMISSING\tx2\n")
+    df = importer.orthologs_to_rbh(
+        orthologs_path=p,
+        bed_paths={"sp1": sp1_bed, "sp2": sp2_bed},
+        species_order=["sp1", "sp2"],
+    )
+    assert len(df) == 1
+    assert df.iloc[0]["sp1_gene"] == "g1"
+    err = capsys.readouterr().err
+    assert "skipped 1 ortholog rows" in err
+
+
+def test_orthologs_to_rbh_missing_bed_for_species_errors(
+    importer, two_species_bed_pair, two_col_orthologs
+):
+    sp1_bed, _ = two_species_bed_pair
+    with pytest.raises(ValueError, match="BED files missing for species"):
+        importer.orthologs_to_rbh(
+            orthologs_path=two_col_orthologs,
+            bed_paths={"sp1": sp1_bed},  # sp2 missing
+            species_order=["sp1", "sp2"],
+        )
+
+
+def test_orthologs_to_rbh_three_species_orthofinder_style(
+    importer, two_species_bed_pair, tmp_path
+):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    # Third species BED
+    sp3_bed = tmp_path / "sp3.bed"
+    sp3_bed.write_text(dedent("""\
+        ctgA\t1\t10\ty1
+        ctgA\t20\t30\ty2
+        ctgB\t100\t200\ty3
+        ctgB\t300\t400\ty4
+    """))
+    # Orthofinder-style table: OG id + 3 species
+    orth = tmp_path / "Single_copy.tsv"
+    orth.write_text(dedent("""\
+        OG0000001\tg1\tx1\ty1
+        OG0000002\tg2\tx2\ty2
+        OG0000003\tg3\tx3\ty3
+        OG0000004\tg4\tx4\ty4
+    """))
+    df = importer.orthologs_to_rbh(
+        orthologs_path=orth,
+        bed_paths={"sp1": sp1_bed, "sp2": sp2_bed, "sp3": sp3_bed},
+        species_order=["sp1", "sp2", "sp3"],
+        has_orthogroup_id_column=True,
+    )
+    assert len(df) == 4
+    assert "sp3_gene" in df.columns
+    assert df.iloc[0]["sp3_gene"] == "y1"
+    assert df.iloc[0]["sp3_scaf"] == "ctgA"
+
+
+def test_orthologs_to_rbh_rejects_zero_rows_after_join(
+    importer, two_species_bed_pair, tmp_path
+):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    p = tmp_path / "miss.tsv"
+    p.write_text("NONE\tNONE\n")
+    with pytest.raises(ValueError, match="zero ortholog rows survived"):
+        importer.orthologs_to_rbh(
+            orthologs_path=p,
+            bed_paths={"sp1": sp1_bed, "sp2": sp2_bed},
+            species_order=["sp1", "sp2"],
+        )
+
+
+def test_write_rbh_round_trip(importer, two_species_bed_pair, two_col_orthologs, tmp_path):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    df = importer.orthologs_to_rbh(
+        orthologs_path=two_col_orthologs,
+        bed_paths={"sp1": sp1_bed, "sp2": sp2_bed},
+        species_order=["sp1", "sp2"],
+    )
+    out = tmp_path / "rbh.tsv"
+    n = importer.write_rbh(df, out)
+    assert n == 4
+    body = out.read_text()
+    assert body.startswith("rbh\tgene_group\tsp1_gene")
+    # Reading it back as a plain TSV recovers the same column count.
+    lines = [l for l in body.split("\n") if l.strip()]
+    assert len(lines) == 5  # 1 header + 4 rows
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_cli_orthologs_to_rbh_two_species(
+    tmp_path, two_species_bed_pair, two_col_orthologs
+):
+    sp1_bed, sp2_bed = two_species_bed_pair
+    out = tmp_path / "rbh.tsv"
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH),
+            "orthologs-to-rbh",
+            "--orthologs", str(two_col_orthologs),
+            "--bed", f"sp1={sp1_bed}",
+            "--bed", f"sp2={sp2_bed}",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.is_file()
+    body = out.read_text()
+    assert "rbh1" in body
+    assert "g1" in body
+
+
+def test_cli_bed_missing_equals_sign(tmp_path):
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH),
+            "orthologs-to-rbh",
+            "--orthologs", "/dev/null",
+            "--bed", "missing_equals",
+            "--output", str(tmp_path / "rbh.tsv"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "expects NAME=PATH" in result.stderr
+
+
+def test_cli_requires_at_least_one_bed(tmp_path, two_col_orthologs):
+    result = subprocess.run(
+        [
+            sys.executable, str(CLI_PATH),
+            "orthologs-to-rbh",
+            "--orthologs", str(two_col_orthologs),
+            "--output", str(tmp_path / "rbh.tsv"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "at least one --bed" in result.stderr
+
+
+def test_cli_help_lists_orthologs_to_rbh():
+    result = subprocess.run(
+        [sys.executable, str(CLI_PATH), "--help"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "orthologs-to-rbh" in result.stdout

--- a/unittesting/test_orthologs_to_rbh.py
+++ b/unittesting/test_orthologs_to_rbh.py
@@ -294,7 +294,7 @@ def test_orthologs_to_rbh_missing_bed_for_species_errors(
     importer, two_species_bed_pair, two_col_orthologs
 ):
     sp1_bed, _ = two_species_bed_pair
-    with pytest.raises(ValueError, match="BED files missing for species"):
+    with pytest.raises(ValueError, match="Coordinate files missing for species"):
         importer.orthologs_to_rbh(
             orthologs_path=two_col_orthologs,
             bed_paths={"sp1": sp1_bed},  # sp2 missing
@@ -405,10 +405,10 @@ def test_cli_bed_missing_equals_sign(tmp_path):
         capture_output=True, text=True,
     )
     assert result.returncode == 2
-    assert "expects NAME=PATH" in result.stderr
+    assert "expected NAME=PATH" in result.stderr
 
 
-def test_cli_requires_at_least_one_bed(tmp_path, two_col_orthologs):
+def test_cli_requires_at_least_one_coord(tmp_path, two_col_orthologs):
     result = subprocess.run(
         [
             sys.executable, str(CLI_PATH),
@@ -419,7 +419,7 @@ def test_cli_requires_at_least_one_bed(tmp_path, two_col_orthologs):
         capture_output=True, text=True,
     )
     assert result.returncode == 2
-    assert "at least one --bed" in result.stderr
+    assert "at least one --chrom or --bed" in result.stderr
 
 
 def test_cli_help_lists_orthologs_to_rbh():


### PR DESCRIPTION
Adds two complementary import paths into the existing odp pipeline so users with pre-computed orthology can skip the all-vs-all diamond/blastp step:

1. `odp orthologs-to-rbh` — join an N-column tab-separated ortholog table with per-species coordinate files (.chrom or BED) and emit an odp-style .rbh table. For users who have already-single-copy orthologs.
2. `odp orthofinder-import` — read a full Orthofinder run directory directly and emit an odp-style .rbh table, rescuing multi-copy orthogroups via one of four selectable strategies.

Both subcommands accept either odp `.chrom` (with `--chrom NAME=PATH`) or BED (with `--bed NAME=PATH`) coordinate files, both gzip-OK, format auto-detected from file content.

## Why

Lots of users have already run Orthofinder on their proteins. Forcing them to re-do the all-vs-all RBH step inside odp is wasteful — both in compute and in user time. The naive workaround (pre-filter `Orthogroups.tsv` to the single-copy subset, throw away every multi-copy row) discards a meaningful fraction of orthogroups, especially when comparing more than two species or when one species has more gene duplications than the others.

The new `orthofinder-import` subcommand rescues multi-copy orthogroups by picking the candidate gene whose chromosome and position best fit the syntenic backbone established by the single-copy orthogroups in the same run.

## Strategies

| `--multi-copy-strategy` | What it does | Use when |
|---|---|---|
| `synteny` (default) | Anchor chromosome-pair compatibility + positional proximity from the single-copy backbone | Default. Best signal. Needs a single-copy backbone. |
| `most-common-chrom` | Chromosome-pair compatibility only, no positional component | BED positions are noisy or coarse. |
| `longest` | Pick the longest CDS per species, chromosome-blind | Backbone is too sparse for chromosome anchoring. |
| `skip` | Drop every multi-copy orthogroup | Matches `fgrep -f Orthogroups_SingleCopyOrthologues.txt` pipelines. |

Plus `--min-confidence N` (default 1.0): orthogroups whose picked-candidate score in any species falls below N are dropped.

## Audit report

`--report PATH` writes a per-decision audit TSV (orthogroup, species, strategy, n_candidates, picked_gene, picked_score, second_best_gene, second_best_score, reason). Lets you spot-check which paralog was picked, why, and whether the alternative was close.

## Files

New:
- `source/ortholog_table_importer.py` — coordinate file parsers (BED + .chrom, gzip-OK, format auto-detection), ortholog-table parser with auto-detection of an orthogroup-id column, and the `orthologs_to_rbh()` join.
- `source/orthofinder_importer.py` — Orthofinder run-dir discovery, Orthogroups.tsv parser, single-copy backbone partitioning, chromosome anchor graph builder, four-strategy disambiguator with per-decision audit, top-level `orthofinder_to_rbh()`.
- `unittesting/test_orthologs_to_rbh.py` (26 cases).
- `unittesting/test_orthofinder_import.py` (20 basic cases).
- `unittesting/test_orthofinder_import_advanced.py` (22 advanced cases: inparalogs, large gene families, sparse/empty backbones, NCBI-style IDs, gzip, CRLF, round-trips, strategy comparisons, performance regression, CLI argument handling).

Modified:
- `bin/odp` — two new subcommand parsers + handlers. `SUBCOMMAND_ORDER` extended. "did you mean" valid-set extended.
- `unittesting/test_cli.py` — expected-subcommands set updated.

## Complementary, not replacing

Nothing existing is modified or removed. All current odp subcommands (`run`, `only-db`, `nway-rbh`, `rbh-to-*`, `plot-mixing`, `filecheck`, `init`, `validate`, `version`) continue to work unchanged. Users who run the full RBH pipeline get the same behaviour as before. The two new subcommands are additional entry points alongside the existing flow.

## Tests

122 unit tests passing locally:
- 49 from the pre-existing suite (CLI parsing, sequence-legality, configfile auto-detect, etc.)
- 26 covering `orthologs-to-rbh` (BED, .chrom, CRLF, multi-copy rejection, header detection, etc.)
- 20 basic `orthofinder-import` (run-dir discovery, parsing, partition, anchor graph, each strategy, top-level entry, CLI)
- 22 advanced `orthofinder-import` (inparalogs, gene-family expansions, sparse/empty backbones, NCBI-style identifiers, gzip, CRLF, round-trip, strategy comparisons, positional tiebreaks, performance, CLI argument validation)

## Test plan

- [ ] CI green on the matrix
- [ ] Manual: run `odp orthofinder-import` against a real Orthofinder run (e.g. an existing project's output) and inspect the audit TSV for the disambiguation decisions
- [ ] Decide on a default --min-confidence based on real-world rescue rates