### PR TITLE
Add odp_rbh_to_polarity: 3-species ribbon polarity plot

### DIFF
--- a/example_configs/CONFIG_rbh_to_polarity_grid.yaml
+++ b/example_configs/CONFIG_rbh_to_polarity_grid.yaml
@@ -1,0 +1,88 @@
+# Example config for odp_rbh_to_polarity (grid mode).
+#
+# Renders an N x M grid of polarity-evidence sandwich panels with:
+#   - one TOP species fixed across the whole grid
+#   - one OUTGROUP species per column
+#   - one FUSED-side species per row
+#
+# Each cell is rendered the same way as the single-panel mode (3-way
+# RBH, color by BCnS / lg2 / raw, etc.) but stripped down to fit a
+# small subplot. Row labels (left margin) and column headers (top
+# strip) carry the species names; per-cell labels use 2-3 char
+# abbreviations.
+
+mode: grid
+
+output_pdf:       polarity_grid.pdf
+figure_width_in:  7.087    # 180 mm
+figure_height_in: 8.5
+
+color_by:     bcns
+bcns_palette: /path/to/odp/LG_db/BCnSSimakov2022/BCnSSimakov2022.rbh
+
+# odp run directories. The script looks up per-pair RBH files via the
+# odp filename convention: {a}_{b}_reciprocal_best_hits.rbh (a, b
+# alphabetical) and the BCnS HMM-RBH files via:
+#   BCnSSimakov2022_{species}_reciprocal_best_hits.hmm.rbh
+rbh_dir:       /path/to/odp/run/step1-rbh
+bcns_hmm_dir:  /path/to/odp/run/step1-rbh
+
+# Top banner text (defaults to "Top row of every panel:" if unset).
+top_banner_text: "Top row of every panel:"
+lg_a_label:      "ALG-A"
+lg_b_label:      "ALG-B"
+
+# Top species (fixed across the whole grid).
+top:
+  name:    speciesA
+  display: "Species A"
+  abbrev:  Sa
+  chr_A:   chr1
+  chr_B:   chr5
+
+# Outgroups (one per column, left -> right).
+outgroups:
+  - name: speciesB1
+    display: "Species B1"
+    abbrev:  Sb1
+    chr_A:   contig_2
+    chr_B:   contig_7
+    group_label: "Group I"          # optional sub-header below the species name
+  - name: speciesB2
+    display: "Species B2"
+    abbrev:  Sb2
+    chr_A:   scaffold_4
+    chr_B:   scaffold_9
+    group_label: "Group II"
+
+# Fused-side species (one per row, top -> bottom).
+bottoms:
+  - name: speciesC1
+    display: "Species C1"
+    abbrev:  Sc1
+    chr_fused: contig_3
+  - name: speciesC2
+    display: "Species C2"
+    abbrev:  Sc2
+    chr_fused: scaffold_8
+
+# Optional: a vertical divider between groups of columns. Set to the
+# 1-based count of outgroup columns to the LEFT of the divider.
+# (Unset or 0 = no divider.)
+# section_divider_after: 1
+# section_label_left:  "Group I outgroups"
+# section_label_right: "Group II outgroups"
+
+# Optional override of the BCnS-ALGs shown in the shared legend.
+# Defaults to the union most commonly seen in metazoan data.
+# legend_algs: ["D", "I", "F", "J1", "J2", "A1a", "A1b", "C1", "Eb", "H", "G", "B1"]
+
+# Optional gridspec layout knobs.
+# grid_left:           0.02
+# grid_right:          0.995
+# grid_top:            0.945
+# grid_bottom:         0.06
+# grid_hspace:         0.05
+# grid_wspace:         0.20
+# grid_header_h_ratio: 0.15
+# grid_label_w_ratio:  0.18

--- a/example_configs/CONFIG_rbh_to_polarity_panel.yaml
+++ b/example_configs/CONFIG_rbh_to_polarity_panel.yaml
@@ -1,0 +1,88 @@
+# Example config for odp_rbh_to_polarity (single-panel mode).
+#
+# Renders a three-row "polarity-evidence sandwich" panel showing how
+# a hypothesized chromosome fusion / fission event maps across three
+# species:
+#
+#   top row     unfused-side species:  two distinct chromosomes
+#                                      carrying two ancestral linkage
+#                                      groups (ALG-A and ALG-B).
+#   middle row  outgroup species:      the two chromosomes that
+#                                      preserve ALG-A and ALG-B as
+#                                      distinct linkage groups.
+#   bottom row  fused-side species:    the single chromosome carrying
+#                                      both linkage groups.
+#
+# Each ribbon traces one gene via 3-way RBH (top <-> middle <-> bot).
+#
+# Run with:
+#   snakemake --snakefile path/to/odp/scripts/odp_rbh_to_polarity \
+#             --configfile this_file.yaml --cores 1
+
+mode: panel
+
+# Output
+output_pdf:       polarity_panel.pdf
+figure_width_in:  7.087    # 180 mm (single Nature/Science column)
+figure_height_in: 4.0
+
+# Coloring: 'bcns' | 'lg2' | 'raw'
+#   bcns - color each ribbon by the BCnS-Simakov2022 ALG of the
+#          underlying gene (looked up via the per-species HMM-RBH
+#          files produced by odp).
+#   lg2  - two-color split keyed to the top-row chromosomes
+#          (top_chrA -> red, top_chrB -> blue).
+#   raw  - single neutral color (no per-ortholog encoding).
+color_by: bcns
+
+# Required by color_by=bcns. Provided by odp's BCnSSimakov2022 LG_db.
+bcns_palette:  /path/to/odp/LG_db/BCnSSimakov2022/BCnSSimakov2022.rbh
+# Per-species BCnS HMM-RBH files (the per-species rows you got by
+# running odp with plot_LGs:True on a config including these species).
+bcns_hmm_top:  /path/to/run/step1-rbh/BCnSSimakov2022_speciesA_reciprocal_best_hits.hmm.rbh
+bcns_hmm_mid:  /path/to/run/step1-rbh/BCnSSimakov2022_speciesB_reciprocal_best_hits.hmm.rbh
+bcns_hmm_bot:  /path/to/run/step1-rbh/BCnSSimakov2022_speciesC_reciprocal_best_hits.hmm.rbh
+
+# Pairwise reciprocal-best-hit files. odp filenames are sorted
+# alphabetically by species, e.g.
+#   speciesA_speciesB_reciprocal_best_hits.rbh
+rbh_top_mid: /path/to/run/step1-rbh/speciesA_speciesB_reciprocal_best_hits.rbh
+rbh_bot_mid: /path/to/run/step1-rbh/speciesB_speciesC_reciprocal_best_hits.rbh
+
+# Top species: unfused side, two chromosomes carry ALG-A and ALG-B.
+top:
+  name:    speciesA       # must match the {name}_gene / _scaf columns in RBH
+  display: "Species A"    # italic label in the figure
+  abbrev:  Sa             # 2-3 char abbrev used inside each panel
+  chr_A:   chr1           # the chromosome carrying ALG-A
+  chr_B:   chr5           # the chromosome carrying ALG-B
+
+# Middle species: outgroup that preserves ALG-A and ALG-B as separate
+# linkage groups.
+mid:
+  name:    speciesB
+  display: "Species B"
+  abbrev:  Sb
+  chr_A:   contig_2
+  chr_B:   contig_7
+
+# Bottom species: the single chromosome carrying both ALG-A and ALG-B
+# (the fused state).
+bot:
+  name:    speciesC
+  display: "Species C"
+  abbrev:  Sc
+  chr_fused: contig_3
+
+# Optional labels used by color_by=lg2 (legend) and the top banner.
+lg_a_label: "ALG-A"
+lg_b_label: "ALG-B"
+
+# Optional layout knobs (sensible defaults for a single panel).
+# chrom_acronyms        : True  -> compress chromosome labels (OZ246644.1 -> OZ44)
+# chrom_gap_frac        : 0.04  -> horizontal gap fraction between bars
+# equal_width_chroms    : False -> if True, chrom bars share the same width
+# highlight_bottom_species : False  -> bold + deep-red prefix for bottom row
+# highlight_middle_species : False  -> bold + deep-navy prefix for middle row
+# label_fontsize        : 7   -> chrom labels and legend (>=6 for paper)
+# species_fontsize      : 10  -> per-row species abbreviation in each panel

--- a/scripts/odp_rbh_to_polarity
+++ b/scripts/odp_rbh_to_polarity
@@ -136,7 +136,10 @@ def _render_grid(out_pdf):
                            width_ratios=[config.get("grid_label_w_ratio", 0.18)]
                                          + [1] * ncols)
 
-    # Top banner
+    # Top banner. Honors chrom_label_map for the chromosome acronyms.
+    _label_map = config.get("chrom_label_map") or {}
+    def _chr_label(c):
+        return _label_map.get(c, pp.chrom_acronym(c))
     banner_text = config.get("top_banner_text",
                               "Top row of every panel:")
     fig.text(0.02, 0.990, banner_text,
@@ -144,9 +147,9 @@ def _render_grid(out_pdf):
     fig.text(0.21, 0.990, top_disp,
              ha="left", va="top", style="italic", weight="bold", fontsize=10)
     fig.text(0.34, 0.990,
-             f"({pp.chrom_acronym(config['top']['chr_A'])} = "
+             f"({_chr_label(config['top']['chr_A'])} = "
              f"{config.get('lg_a_label', 'ALG-A')},  "
-             f"{pp.chrom_acronym(config['top']['chr_B'])} = "
+             f"{_chr_label(config['top']['chr_B'])} = "
              f"{config.get('lg_b_label', 'ALG-B')})",
              ha="left", va="top", fontsize=8, color="0.30")
 

--- a/scripts/odp_rbh_to_polarity
+++ b/scripts/odp_rbh_to_polarity
@@ -1,0 +1,287 @@
+"""
+odp_rbh_to_polarity
+
+Renders a "polarity-evidence" sandwich panel (or a grid of panels)
+showing how a hypothesized chromosome fusion / fission event maps
+across three species, using pairwise reciprocal-best-hits (RBH) files
+produced by odp.
+
+Modes
+-----
+config["mode"]: "panel" | "grid"
+
+  "panel"  - render one 3-row panel into a single output PDF.
+             Required config keys: rbh_top_mid, rbh_bot_mid, top, mid,
+             bot (each with `name`, optionally `abbrev`, `display`,
+             plus chromosome IDs).
+  "grid"   - render a matrix of panels. Required config keys: top
+             (single species), outgroups (list, one per column),
+             bottoms (list, one per row), plus rbh_dir / bcns_hmm_dir
+             so the script can look up the pairwise RBH files.
+
+See example_configs/CONFIG_rbh_to_polarity_panel.yaml and
+example_configs/CONFIG_rbh_to_polarity_grid.yaml for layouts.
+"""
+import os
+import sys
+snakefile_path = os.path.dirname(os.path.realpath(workflow.snakefile))
+source_path = os.path.join(snakefile_path, "../source")
+sys.path.insert(1, source_path)
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.lines
+
+import odp_polarity_plot as pp
+
+
+configfile: "config.yaml"
+
+
+# ---------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------
+_MODE = config.get("mode", "panel")
+if _MODE not in ("panel", "grid"):
+    sys.exit("ERROR: config['mode'] must be 'panel' or 'grid'.")
+
+config.setdefault("color_by", "bcns")
+config.setdefault("bcns_palette", None)
+config.setdefault("output_pdf", "polarity.pdf")
+config.setdefault("figure_width_in", 7.087)   # 180 mm default
+config.setdefault("figure_height_in", 4.0)
+
+
+def _sp_keys(d):
+    """Return (name, abbrev, display) for a species block in the config."""
+    return d["name"], d.get("abbrev", d["name"][:3]), \
+           d.get("display", d["name"])
+
+
+def _pairwise_rbh(rbh_dir, sp1, sp2):
+    a, b = sorted([sp1, sp2])
+    return os.path.join(rbh_dir, f"{a}_{b}_reciprocal_best_hits.rbh")
+
+
+def _bcns_hmm(bcns_dir, sp):
+    return os.path.join(bcns_dir,
+                        f"BCnSSimakov2022_{sp}_reciprocal_best_hits.hmm.rbh")
+
+
+# ---------------------------------------------------------------------
+# Single-panel rendering
+# ---------------------------------------------------------------------
+def _render_single_panel(out_pdf):
+    top, top_abbr, top_disp = _sp_keys(config["top"])
+    mid, mid_abbr, mid_disp = _sp_keys(config["mid"])
+    bot, bot_abbr, bot_disp = _sp_keys(config["bot"])
+
+    fig = plt.figure(figsize=(config["figure_width_in"],
+                              config["figure_height_in"]))
+    ax = fig.add_axes([0.10, 0.10, 0.85, 0.78])
+    stats = pp.draw_polarity_panel(
+        ax,
+        top_sp=top, top_chrA=config["top"]["chr_A"], top_chrB=config["top"]["chr_B"],
+        mid_sp=mid, mid_chrA=config["mid"]["chr_A"], mid_chrB=config["mid"]["chr_B"],
+        bot_sp=bot, bot_chr_fused=config["bot"]["chr_fused"],
+        rbh_top_mid=config["rbh_top_mid"],
+        rbh_bot_mid=config["rbh_bot_mid"],
+        color_by=config["color_by"],
+        bcns_hmm_top=config.get("bcns_hmm_top"),
+        bcns_hmm_mid=config.get("bcns_hmm_mid"),
+        bcns_hmm_bot=config.get("bcns_hmm_bot"),
+        bcns_palette=config["bcns_palette"],
+        top_abbrev=top_abbr, mid_abbrev=mid_abbr, bot_abbrev=bot_abbr,
+        chrom_acronyms=config.get("chrom_acronyms", False),
+        chrom_gap_frac=config.get("chrom_gap_frac", 0.04),
+        equal_width_chroms=config.get("equal_width_chroms", False),
+        highlight_bottom_species=config.get("highlight_bottom_species", False),
+        highlight_middle_species=config.get("highlight_middle_species", False),
+        label_fontsize=config.get("label_fontsize", 7),
+        species_fontsize=config.get("species_fontsize", 10),
+        lg_a_label=config.get("lg_a_label", "ALG-A"),
+        lg_b_label=config.get("lg_b_label", "ALG-B"),
+    )
+    fig.savefig(out_pdf, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {out_pdf}  (n_triplets={stats['n_triplets']})", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------
+# Grid rendering (rows = bottom species, cols = outgroup species,
+# single top species across the whole grid).
+# ---------------------------------------------------------------------
+def _render_grid(out_pdf):
+    top, top_abbr, top_disp = _sp_keys(config["top"])
+    outgroups = config["outgroups"]   # list of dicts
+    bottoms   = config["bottoms"]     # list of dicts
+    rbh_dir   = config["rbh_dir"]
+    bcns_dir  = config.get("bcns_hmm_dir", rbh_dir)
+
+    nrows = len(bottoms)
+    ncols = len(outgroups)
+
+    fig = plt.figure(figsize=(config["figure_width_in"],
+                              config["figure_height_in"]))
+    gs = fig.add_gridspec(nrows=nrows + 1, ncols=ncols + 1,
+                           left=config.get("grid_left", 0.02),
+                           right=config.get("grid_right", 0.995),
+                           top=config.get("grid_top", 0.945),
+                           bottom=config.get("grid_bottom", 0.06),
+                           hspace=config.get("grid_hspace", 0.05),
+                           wspace=config.get("grid_wspace", 0.20),
+                           height_ratios=[config.get("grid_header_h_ratio", 0.15)]
+                                          + [1] * nrows,
+                           width_ratios=[config.get("grid_label_w_ratio", 0.18)]
+                                         + [1] * ncols)
+
+    # Top banner
+    banner_text = config.get("top_banner_text",
+                              "Top row of every panel:")
+    fig.text(0.02, 0.990, banner_text,
+             ha="left", va="top", fontsize=8, color="0.30")
+    fig.text(0.21, 0.990, top_disp,
+             ha="left", va="top", style="italic", weight="bold", fontsize=10)
+    fig.text(0.34, 0.990,
+             f"({pp.chrom_acronym(config['top']['chr_A'])} = "
+             f"{config.get('lg_a_label', 'ALG-A')},  "
+             f"{pp.chrom_acronym(config['top']['chr_B'])} = "
+             f"{config.get('lg_b_label', 'ALG-B')})",
+             ha="left", va="top", fontsize=8, color="0.30")
+
+    # Column headers (middle species)
+    for j, og in enumerate(outgroups, start=1):
+        og_name, og_abbr, og_disp = _sp_keys(og)
+        hax = fig.add_subplot(gs[0, j])
+        hax.axis("off")
+        hax.text(0.5, 0.55, og_disp,
+                 ha="center", va="center", style="italic", weight="bold",
+                 color=pp.LABEL_COLOR_MIDDLE, fontsize=9,
+                 transform=hax.transAxes)
+        if "group_label" in og:
+            hax.text(0.5, 0.10, og["group_label"],
+                     ha="center", va="center", fontsize=7, color="0.35",
+                     transform=hax.transAxes)
+
+    # Row labels (bottom species)
+    for i, bot in enumerate(bottoms, start=1):
+        bot_name, bot_abbr, bot_disp = _sp_keys(bot)
+        rax = fig.add_subplot(gs[i, 0])
+        rax.axis("off")
+        rax.text(0.95, 0.60, bot_abbr,
+                 ha="right", va="center", style="italic", weight="bold",
+                 color=pp.LABEL_COLOR_BOTTOM, fontsize=14,
+                 transform=rax.transAxes)
+        rax.text(0.95, 0.30,
+                 f"fused chrom\n{pp.chrom_acronym(bot['chr_fused'])}",
+                 ha="right", va="center", fontsize=7, color="0.30",
+                 linespacing=1.1, transform=rax.transAxes)
+
+    # Optional section divider (e.g. metazoan / non-metazoan).
+    if "section_divider_after" in config:
+        n_left = int(config["section_divider_after"])
+        if 0 < n_left < ncols:
+            x_div = gs[0, n_left + 1].get_position(fig).x0 - 0.020
+            line = matplotlib.lines.Line2D([x_div, x_div], [0.06, 0.94],
+                                            color="0.7", lw=0.5,
+                                            transform=fig.transFigure,
+                                            figure=fig)
+            fig.lines.append(line)
+            if "section_label_left" in config:
+                fig.text(x_div - 0.10, 0.962, config["section_label_left"],
+                         ha="right", va="center", fontsize=8, color="0.25")
+            if "section_label_right" in config:
+                fig.text(x_div + 0.005, 0.962, config["section_label_right"],
+                         ha="left", va="center", fontsize=8, color="0.25")
+
+    # Panel cells
+    panel_stats = []
+    for i, bot in enumerate(bottoms, start=1):
+        bot_name, bot_abbr, bot_disp = _sp_keys(bot)
+        for j, og in enumerate(outgroups, start=1):
+            og_name, og_abbr, og_disp = _sp_keys(og)
+            ax = fig.add_subplot(gs[i, j])
+            stats = pp.draw_polarity_panel(
+                ax,
+                top_sp=top,    top_chrA=config["top"]["chr_A"],
+                               top_chrB=config["top"]["chr_B"],
+                mid_sp=og_name, mid_chrA=og["chr_A"], mid_chrB=og["chr_B"],
+                bot_sp=bot_name, bot_chr_fused=bot["chr_fused"],
+                rbh_top_mid=_pairwise_rbh(rbh_dir, top, og_name),
+                rbh_bot_mid=_pairwise_rbh(rbh_dir, bot_name, og_name),
+                color_by=config["color_by"],
+                bcns_hmm_top=_bcns_hmm(bcns_dir, top),
+                bcns_hmm_mid=_bcns_hmm(bcns_dir, og_name),
+                bcns_hmm_bot=_bcns_hmm(bcns_dir, bot_name),
+                bcns_palette=config["bcns_palette"],
+                top_abbrev=top_abbr, mid_abbrev=og_abbr, bot_abbrev=bot_abbr,
+                show_chrom_labels=True,
+                show_species_labels=True,
+                show_legend=False,
+                chrom_acronyms=True,
+                chrom_label_map=config.get("chrom_label_map"),
+                chrom_gap_frac=config.get("chrom_gap_frac", 0.15),
+                equal_width_chroms=config.get("equal_width_chroms", True),
+                highlight_bottom_species=True,
+                highlight_middle_species=True,
+                label_fontsize=6,
+                species_fontsize=6,
+                lg_a_label=config.get("lg_a_label", "ALG-A"),
+                lg_b_label=config.get("lg_b_label", "ALG-B"),
+            )
+            panel_stats.append((bot_name, og_name, stats))
+            ax.text(0.5, 0.12, f"n = {stats['n_triplets']} orthologs",
+                    ha="center", va="top", fontsize=6, color="0.25",
+                    transform=ax.transAxes)
+
+    # Shared legend at the bottom (BCnS palette).
+    if config["color_by"] == "bcns" and config.get("bcns_palette"):
+        import pandas as pd
+        import matplotlib.patches as mpatches
+        palette_df = pp.load_rbh(config["bcns_palette"])
+        alg_to_color = (palette_df[["gene_group", "color"]]
+                          .drop_duplicates().dropna()
+                          .set_index("gene_group")["color"].to_dict())
+        legend_algs = config.get("legend_algs",
+                                  ["D", "I", "F", "J1", "J2", "A1a", "A1b",
+                                   "C1", "Eb", "H", "G", "B1"])
+        legend_elems = [
+            mpatches.Patch(facecolor=alg_to_color.get(a, "#888"),
+                            edgecolor="none", label=f"BCnS-{a}")
+            for a in legend_algs
+        ]
+        legend_elems.append(
+            mpatches.Patch(facecolor=pp.FALLBACK_GREY, edgecolor="none",
+                            label="no BCnS call"))
+        lax = fig.add_axes([0.04, 0.005, 0.92, 0.025])
+        lax.axis("off")
+        lax.legend(handles=legend_elems, loc="center",
+                   ncol=min(len(legend_elems), 7),
+                   frameon=False, fontsize=7)
+
+    fig.savefig(out_pdf, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {out_pdf}", file=sys.stderr)
+    print("\n=== panel n_triplets summary ===", file=sys.stderr)
+    print(f"{'bottom':<24} {'outgroup':<24} n_triplets", file=sys.stderr)
+    for bot_name, og_name, st in panel_stats:
+        print(f"{bot_name:<24} {og_name:<24} {st['n_triplets']}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------
+# Snakemake rule
+# ---------------------------------------------------------------------
+rule all:
+    input:
+        config["output_pdf"]
+
+
+rule render:
+    output:
+        pdf = config["output_pdf"]
+    run:
+        if _MODE == "panel":
+            _render_single_panel(output.pdf)
+        else:
+            _render_grid(output.pdf)

--- a/source/odp_polarity_plot.py
+++ b/source/odp_polarity_plot.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+Polarity-evidence ribbon panel.
+
+A 3-row ribbon plot showing how a hypothesized fusion / fission event
+maps across three species:
+
+    top row     unfused-side species: two distinct chromosomes carrying
+                two ancestral linkage groups (e.g. ALG-A and ALG-B).
+    middle row  outgroup species: the two chromosomes that preserve
+                ALG-A and ALG-B as distinct linkage groups.
+    bottom row  fused-side species: the single chromosome carrying
+                both ALG-A and ALG-B.
+
+Each ribbon traces one gene via 3-way RBH (top <-> middle <-> bottom).
+Ribbons can be colored by:
+  * `bcns`    - BCnS-Simakov2022 ALG (uses HMM-RBH calls)
+  * `lg2`     - two-color split keyed to the top-row chromosomes
+  * `raw`     - single neutral color
+
+The module exposes `draw_polarity_panel(ax, ...)` so callers can compose
+multiple panels into a grid (e.g. one outgroup per column, one
+fused-side species per row).
+"""
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.path import Path as MplPath
+import matplotlib.patches as mpatches
+import pandas as pd
+
+
+# -- defaults / constants ----------------------------------------------------
+
+# Two-color split for the `lg2` coloring scheme.
+COLOR_LG2_A = "#B7202A"   # ALG-A side (top-chrom #1)
+COLOR_LG2_B = "#1F4A8F"   # ALG-B side (top-chrom #2)
+FALLBACK_GREY = "#888888"
+
+# Deep-saturated label colors picked to NOT collide with the BCnS palette
+# or the lg2 two-color split. Used to tie the in-cell prefix to its
+# matching grid label.
+LABEL_COLOR_BOTTOM = "#8B0000"   # DarkRed: bottom-row prefix + row label
+LABEL_COLOR_MIDDLE = "#00264D"   # Deep navy: middle-row prefix + col header
+LABEL_COLOR_TOP    = "#000000"   # black (neutral)
+
+ROW_Y = {"top": 0, "middle": 1, "bottom": 2}
+
+
+# -- I/O helpers -------------------------------------------------------------
+
+def load_rbh(path: str | Path) -> pd.DataFrame:
+    return pd.read_csv(path, sep="\t")
+
+
+def load_bcns_map(hmm_rbh_path: str | Path, gene_col: str) -> dict:
+    """Map {species_gene -> BCnS ALG name} from an odp BCnS HMM-RBH file."""
+    p = Path(hmm_rbh_path)
+    if not p.exists():
+        return {}
+    df = load_rbh(p)
+    if gene_col not in df.columns or "BCnSSimakov2022_scaf" not in df.columns:
+        return {}
+    return dict(zip(df[gene_col], df["BCnSSimakov2022_scaf"]))
+
+
+# -- string helpers ----------------------------------------------------------
+
+def chrom_acronym(chrom: str) -> str:
+    """Compact label for a chromosome ID. Strips accession version and
+    common GenBank-style prefixes, keeping the distinguishing suffix."""
+    s = chrom.rstrip()
+    s = re.sub(r"\.\d+$", "", s)
+    for pat, fmt in (
+        (r"^HiC_scaffold_(\d+)$", "HiC{0}"),
+        (r"^NW_\d+(\d{3})$",       "NW{0}"),
+        (r"^NC_\d+(\d{2})$",       "NC{0}"),
+        (r"^OZ\d+(\d{2})$",        "OZ{0}"),
+        (r"^CM\d+(\d{2})$",        "CM{0}"),
+    ):
+        m = re.match(pat, s)
+        if m:
+            return fmt.format(m.group(1))
+    return s
+
+
+# -- layout helpers ----------------------------------------------------------
+
+def layout_chroms(chroms: list[str], widths: dict, x_left: float, x_right: float,
+                  gap_frac: float = 0.04) -> dict:
+    """Return {chrom: (x_start, x_end)} sized by `widths` with gaps."""
+    total = sum(widths.values()) or 1
+    span = x_right - x_left
+    gap_total = gap_frac * span * max(0, len(chroms) - 1)
+    chrom_span = span - gap_total
+    out = {}
+    x = x_left
+    for i, c in enumerate(chroms):
+        w = chrom_span * widths[c] / total
+        out[c] = (x, x + w)
+        x += w + (gap_frac * span if i < len(chroms) - 1 else 0)
+    return out
+
+
+def gene_x(chrom: str, pos_index: int, n_on_chrom: int, layout: dict) -> float:
+    x0, x1 = layout[chrom]
+    if n_on_chrom <= 1:
+        return (x0 + x1) / 2
+    return x0 + (pos_index / (n_on_chrom - 1)) * (x1 - x0)
+
+
+def bezier_ribbon(ax, x_top, y_top, x_bot, y_bot, color, alpha=0.4, lw=0.4):
+    dy = y_bot - y_top
+    verts = [(x_top, y_top), (x_top, y_top + dy * 0.5),
+             (x_bot, y_top + dy * 0.5), (x_bot, y_bot)]
+    codes = [MplPath.MOVETO, MplPath.CURVE4, MplPath.CURVE4, MplPath.CURVE4]
+    patch = mpatches.PathPatch(MplPath(verts, codes), fill=False, lw=lw,
+                                edgecolor=color, alpha=alpha, capstyle="round")
+    ax.add_patch(patch)
+
+
+def _index_within_chrom(df: pd.DataFrame, scaf_col: str, pos_col: str,
+                         idx_col: str, n_col: str) -> pd.DataFrame:
+    df = df.copy()
+    df[idx_col] = (df.groupby(scaf_col)[pos_col].rank(method="first")
+                     .astype(int) - 1)
+    df[n_col]   = df.groupby(scaf_col)[pos_col].transform("count")
+    return df
+
+
+# -- core rendering function -------------------------------------------------
+
+def draw_polarity_panel(ax, *,
+                         top_sp: str, top_chrA: str, top_chrB: str,
+                         mid_sp: str, mid_chrA: str, mid_chrB: str,
+                         bot_sp: str, bot_chr_fused: str,
+                         rbh_top_mid: str | Path,
+                         rbh_bot_mid: str | Path,
+                         color_by: str = "bcns",
+                         bcns_hmm_top: str | Path | None = None,
+                         bcns_hmm_mid: str | Path | None = None,
+                         bcns_hmm_bot: str | Path | None = None,
+                         bcns_palette: str | Path | None = None,
+                         top_abbrev: str | None = None,
+                         mid_abbrev: str | None = None,
+                         bot_abbrev: str | None = None,
+                         show_chrom_labels: bool = True,
+                         show_species_labels: bool = True,
+                         show_legend: bool = True,
+                         legend_outside: bool = False,
+                         chrom_acronyms: bool = False,
+                         chrom_label_map: dict | None = None,
+                         chrom_gap_frac: float = 0.04,
+                         equal_width_chroms: bool = False,
+                         highlight_bottom_species: bool = False,
+                         highlight_middle_species: bool = False,
+                         label_fontsize: int = 7,
+                         species_fontsize: int = 10,
+                         lg_a_label: str = "ALG-A",
+                         lg_b_label: str = "ALG-B") -> dict:
+    """
+    Draw one polarity-evidence panel into an existing matplotlib axes.
+
+    Returns a dict with summary stats (n_triplets, n_unmapped).
+
+    Required arguments
+    ------------------
+    top_sp / top_chrA / top_chrB
+        Top-row species and its two chromosomes carrying ALG-A and ALG-B.
+    mid_sp / mid_chrA / mid_chrB
+        Middle (outgroup) species and the two chromosomes that preserve
+        ALG-A and ALG-B as distinct linkage groups.
+    bot_sp / bot_chr_fused
+        Bottom species and the single chromosome carrying both ALGs.
+    rbh_top_mid / rbh_bot_mid
+        Paths to the pairwise reciprocal-best-hits TSV files
+        (top<->mid and bot<->mid).
+    """
+    # -------------------------------------------------------------------
+    # Build 3-way RBH triplets
+    # -------------------------------------------------------------------
+    TOP, MID, BOT = top_sp, mid_sp, bot_sp
+    TOP_GENE, TOP_SCAF, TOP_POS = f"{TOP}_gene", f"{TOP}_scaf", f"{TOP}_pos"
+    MID_GENE, MID_SCAF, MID_POS = f"{MID}_gene", f"{MID}_scaf", f"{MID}_pos"
+    BOT_GENE, BOT_SCAF, BOT_POS = f"{BOT}_gene", f"{BOT}_scaf", f"{BOT}_pos"
+
+    tm = load_rbh(rbh_top_mid)
+    bm = load_rbh(rbh_bot_mid)
+    triplets = tm.merge(bm, on=MID_GENE, suffixes=("_tm", "_bm"))
+    triplets[MID_SCAF] = triplets[f"{MID_SCAF}_tm"]
+    triplets[MID_POS]  = triplets[f"{MID_POS}_tm"]
+    triplets = triplets[
+        triplets[TOP_SCAF].isin([top_chrA, top_chrB]) &
+        triplets[BOT_SCAF].isin([bot_chr_fused]) &
+        triplets[MID_SCAF].isin([mid_chrA, mid_chrB])
+    ].copy()
+    n_total = len(triplets)
+    if n_total == 0:
+        ax.text(0.5, 0.5, f"no 3-way triplets\n{top_sp}/{mid_sp}/{bot_sp}",
+                ha="center", va="center", fontsize=7, color="0.4",
+                transform=ax.transAxes)
+        for s in ("top", "right", "bottom", "left"):
+            ax.spines[s].set_visible(False)
+        ax.set_xticks([]); ax.set_yticks([])
+        return {"n_triplets": 0, "n_unmapped": 0}
+
+    top_chroms = [top_chrA, top_chrB]
+    mid_chroms = [mid_chrA, mid_chrB]
+    bot_chroms = [bot_chr_fused]
+
+    def widths_for(col, chroms):
+        if equal_width_chroms:
+            return {c: 1 for c in chroms}
+        v = triplets[col].value_counts()
+        return {c: int(v.get(c, 0)) for c in chroms}
+
+    top_layout = layout_chroms(top_chroms, widths_for(TOP_SCAF, top_chroms),
+                                0.18, 0.82, gap_frac=chrom_gap_frac)
+    mid_layout = layout_chroms(mid_chroms, widths_for(MID_SCAF, mid_chroms),
+                                0.18, 0.82, gap_frac=chrom_gap_frac)
+    bot_layout = layout_chroms(bot_chroms, widths_for(BOT_SCAF, bot_chroms),
+                                0.18, 0.82, gap_frac=chrom_gap_frac)
+
+    triplets = triplets.sort_values([TOP_SCAF, TOP_POS]).reset_index(drop=True)
+    triplets = _index_within_chrom(triplets, TOP_SCAF, TOP_POS, "_top_idx", "_top_n")
+    triplets = _index_within_chrom(triplets, MID_SCAF, MID_POS, "_mid_idx", "_mid_n")
+    triplets = _index_within_chrom(triplets, BOT_SCAF, BOT_POS, "_bot_idx", "_bot_n")
+
+    # -------------------------------------------------------------------
+    # Coloring
+    # -------------------------------------------------------------------
+    legend_elems = []
+    if color_by == "lg2":
+        def color_for_row(r):
+            return COLOR_LG2_A if r[TOP_SCAF] == top_chrA else COLOR_LG2_B
+        legend_elems = [
+            mpatches.Patch(facecolor=COLOR_LG2_A, edgecolor="none", label=lg_a_label),
+            mpatches.Patch(facecolor=COLOR_LG2_B, edgecolor="none", label=lg_b_label),
+        ]
+    elif color_by == "bcns":
+        if bcns_palette is None:
+            raise ValueError("bcns_palette path is required when color_by='bcns'")
+        top_map = load_bcns_map(bcns_hmm_top, f"{TOP}_gene") if bcns_hmm_top else {}
+        mid_map = load_bcns_map(bcns_hmm_mid, f"{MID}_gene") if bcns_hmm_mid else {}
+        bot_map = load_bcns_map(bcns_hmm_bot, f"{BOT}_gene") if bcns_hmm_bot else {}
+        triplets["_alg_top"] = triplets[TOP_GENE].map(top_map)
+        triplets["_alg_mid"] = triplets[MID_GENE].map(mid_map)
+        triplets["_alg_bot"] = triplets[BOT_GENE].map(bot_map)
+        triplets["_alg"] = (triplets["_alg_top"]
+                              .fillna(triplets["_alg_mid"])
+                              .fillna(triplets["_alg_bot"]))
+        palette_df = load_rbh(bcns_palette)
+        alg_to_color = (palette_df[["gene_group", "color"]]
+                          .drop_duplicates().dropna()
+                          .set_index("gene_group")["color"].to_dict())
+
+        def color_for_row(r):
+            return alg_to_color.get(r["_alg"], FALLBACK_GREY)
+
+        algs_used = triplets["_alg"].dropna().value_counts().index.tolist()
+        legend_elems = [
+            mpatches.Patch(facecolor=alg_to_color.get(a, FALLBACK_GREY),
+                            edgecolor="none", label=f"BCnS-{a}")
+            for a in algs_used
+        ]
+        n_unmapped = triplets["_alg"].isna().sum()
+        if n_unmapped > 0:
+            legend_elems.append(
+                mpatches.Patch(facecolor=FALLBACK_GREY, edgecolor="none",
+                                label=f"no BCnS call (n={n_unmapped})"))
+    else:   # raw
+        def color_for_row(r):
+            return "#444444"
+        legend_elems = []
+
+    # -------------------------------------------------------------------
+    # Axes setup
+    # -------------------------------------------------------------------
+    ax.set_xlim(0, 1)
+    ax.set_ylim(-0.4, len(ROW_Y) - 1 + 0.4)
+    ax.set_ylim(ax.get_ylim()[::-1])
+    for s in ("top", "right", "bottom", "left"):
+        ax.spines[s].set_visible(False)
+    ax.set_xticks([]); ax.set_yticks([])
+
+    def draw_chroms(layout: dict, y: float, chrom_labels: dict | None):
+        for c, (x0, x1) in layout.items():
+            ax.plot([x0, x1], [y, y], color="black", lw=2.0,
+                    solid_capstyle="round", clip_on=False)
+            if chrom_labels is None or chrom_labels.get(c) is None:
+                continue
+            label = chrom_labels[c]
+            ax.text(x0 + 0.002, y - 0.04, label,
+                    ha="left", va="bottom",
+                    rotation=90, rotation_mode="anchor",
+                    fontsize=label_fontsize, zorder=200, clip_on=False)
+
+    if show_chrom_labels:
+        _override = chrom_label_map or {}
+        def _lab(c):
+            if c in _override:
+                return _override[c]
+            return chrom_acronym(c) if chrom_acronyms else c
+        top_labels = {top_chrA: _lab(top_chrA), top_chrB: _lab(top_chrB)}
+        mid_labels = {mid_chrA: _lab(mid_chrA), mid_chrB: _lab(mid_chrB)}
+        bot_labels = {bot_chr_fused: _lab(bot_chr_fused)}
+    else:
+        top_labels = mid_labels = bot_labels = None
+
+    draw_chroms(top_layout, ROW_Y["top"],    top_labels)
+    draw_chroms(mid_layout, ROW_Y["middle"], mid_labels)
+    draw_chroms(bot_layout, ROW_Y["bottom"], bot_labels)
+
+    if show_species_labels:
+        ta = top_abbrev or top_sp[:3]
+        ma = mid_abbrev or mid_sp[:3]
+        ba = bot_abbrev or bot_sp[:3]
+        species_rows = [
+            (ROW_Y["top"],    ta, "normal", LABEL_COLOR_TOP),
+            (ROW_Y["middle"], ma,
+                "bold" if highlight_middle_species else "normal",
+                LABEL_COLOR_MIDDLE if highlight_middle_species else LABEL_COLOR_TOP),
+            (ROW_Y["bottom"], ba,
+                "bold" if highlight_bottom_species else "normal",
+                LABEL_COLOR_BOTTOM if highlight_bottom_species else LABEL_COLOR_TOP),
+        ]
+        for y, name, weight, color in species_rows:
+            ax.text(0.04, y, name, ha="right", va="center",
+                    style="italic", weight=weight, color=color,
+                    fontsize=species_fontsize,
+                    clip_on=False, zorder=210)
+
+    # -------------------------------------------------------------------
+    # Ribbons
+    # -------------------------------------------------------------------
+    if color_by == "bcns":
+        draw_order = pd.concat([triplets[triplets["_alg"].isna()],
+                                 triplets[triplets["_alg"].notna()]])
+        ribbon_alpha = lambda r: 0.45 if pd.isna(r.get("_alg")) else 0.65
+        ribbon_lw    = lambda r: 0.55 if pd.isna(r.get("_alg")) else 0.55
+    else:
+        draw_order = triplets
+        ribbon_alpha = lambda r: 0.5
+        ribbon_lw    = lambda r: 0.5
+
+    for _, row in draw_order.iterrows():
+        color = color_for_row(row)
+        tx = gene_x(row[TOP_SCAF], row["_top_idx"], row["_top_n"], top_layout)
+        mx = gene_x(row[MID_SCAF], row["_mid_idx"], row["_mid_n"], mid_layout)
+        bx = gene_x(row[BOT_SCAF], row["_bot_idx"], row["_bot_n"], bot_layout)
+        a, l = ribbon_alpha(row), ribbon_lw(row)
+        bezier_ribbon(ax, tx, ROW_Y["top"],    mx, ROW_Y["middle"], color, alpha=a, lw=l)
+        bezier_ribbon(ax, mx, ROW_Y["middle"], bx, ROW_Y["bottom"], color, alpha=a, lw=l)
+
+    if show_legend and legend_elems:
+        ncol = min(len(legend_elems), 7)
+        ax.legend(handles=legend_elems, loc="lower center",
+                  bbox_to_anchor=(0.5, -0.10), ncol=ncol,
+                  frameon=False, fontsize=label_fontsize)
+
+    n_unmapped = (int(triplets["_alg"].isna().sum())
+                   if color_by == "bcns" else 0)
+    return {"n_triplets": n_total, "n_unmapped": n_unmapped}

--- a/source/odp_polarity_plot.py
+++ b/source/odp_polarity_plot.py
@@ -81,8 +81,11 @@ def chrom_acronym(chrom: str) -> str:
         (r"^NC_\d+(\d{2})$",       "NC{0}"),
         (r"^OZ\d+(\d{2})$",        "OZ{0}"),
         (r"^CM\d+(\d{2})$",        "CM{0}"),
+        # Generic "*_chrN" / "*_chromN" — picks up haplotype-resolved
+        # assemblies like eupHapAv0.3_chr1, Foo_chr14, asm_chrom5, etc.
+        (r"_chr(?:om)?(\d+)$",     "chr{0}"),
     ):
-        m = re.match(pat, s)
+        m = re.search(pat, s) if pat.startswith("_") else re.match(pat, s)
         if m:
             return fmt.format(m.group(1))
     return s


### PR DESCRIPTION
Renders a 3-row "polarity-evidence" panel showing how a hypothesized chromosome fusion/fission event maps across three species via a 3-way RBH inner join.

  top    = unfused-side species (two distinct chromosomes carrying ALG-A and ALG-B)
  middle = outgroup species (two chromosomes preserving ALG-A/B as distinct)
  bottom = fused-side species (one chromosome carrying both ALGs)

Two modes (config[\`mode\`]):
- \`panel\` - single 3-row panel to a PDF
- \`grid\` - N x M grid of panels (single top species across the whole grid; lists of outgroup + bottom species drive the rows/cols)

Coloring (config[\`color_by\`]):
- \`bcns\` - per-ortholog BCnS-Simakov2022 ALG (uses HMM-RBH calls; union across the 3 species)
- \`lg2\` - two-color split keyed to the top-row chromosomes
- \`raw\` - single neutral color

Adds:
- \`source/odp_polarity_plot.py\` - rendering function + helpers
- \`scripts/odp_rbh_to_polarity\` - snakefile CLI
- \`example_configs/CONFIG_rbh_to_polarity_panel.yaml\` - single-panel example
- \`example_configs/CONFIG_rbh_to_polarity_grid.yaml\` - grid example

The grid mode auto-discovers per-pair RBH files via odp's filename convention (\`{a}_{b}_reciprocal_best_hits.rbh\`) and per-species BCnS-HMM-RBH files (\`BCnSSimakov2022_{species}_reciprocal_best_hits.hmm.rbh\`).

Config supports \`chrom_label_map\` for user-defined chromosome label overrides (any chrom in the map is replaced by the supplied label; otherwise \`chrom_acronym\` strips common prefixes).