### PR TITLE
CONFIG_odp_nway_rbh.yaml: document color_palette and random_colors

### DIFF
--- a/example_configs/CONFIG_odp_nway_rbh.yaml
+++ b/example_configs/CONFIG_odp_nway_rbh.yaml
@@ -49,6 +49,17 @@ chromosome_order:
       - chrB
 
 
+# Optional. Sets the colors of the linkage groups in the ribbon diagram.
+#  color_palette selects a curated, repeatable palette. Valid values:
+#    mypals25   - 25-color qualitative palette (default)
+#    tableau20  - the Tableau 20 palette
+color_palette: "mypals25"
+
+# Optional. If True, linkage group colors are generated randomly instead of
+#  being drawn from color_palette. Default is False.
+random_colors: False
+
+
 num_permutations: 1000000
 
 species:


### PR DESCRIPTION
`scripts/odp_nway_rbh` reads `color_palette` and `random_colors` to color the ribbon diagram (odp_nway_rbh:637-640), but `example_configs/CONFIG_odp_nway_rbh.yaml` documented neither. Add both as optional fields with their defaults (`mypals25`, `False`).

Refs #31