### PR TITLE
Citing odp: also cite Schultz et al. 2026 for the newer parts

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,9 @@
 cff-version: 1.2.0
 message: >-
-  If you use odp, please cite the preferred citation below. If you use the ALG
-  decay analysis (plot_LG_decay), odp_onlyDB, odp_filechecker, or odp's
-  per-species ALG .rbh files as input to an evolutionary genome topology
-  analysis, please additionally cite the Science Advances paper listed under
-  references. See the "Citing odp" section of docs/README.md.
+  If you use odp, please cite the preferred citation below. Please also cite the
+  Science Advances paper under references if you use the ALG decay analysis
+  (plot_LG_decay), odp_onlyDB, odp_filechecker, or odp's per-species ALG .rbh
+  files as input to an evolutionary genome topology analysis.
 title: "odp: oxford dot plots"
 license: MIT
 repository-code: "https://github.com/conchoecia/odp"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,60 @@
+cff-version: 1.2.0
+message: >-
+  If you use odp, please cite the preferred citation below. If you use the ALG
+  decay analysis (plot_LG_decay), odp_onlyDB, odp_filechecker, or odp's
+  per-species ALG .rbh files as input to an evolutionary genome topology
+  analysis, please additionally cite the Science Advances paper listed under
+  references. See the "Citing odp" section of docs/README.md.
+title: "odp: oxford dot plots"
+license: MIT
+repository-code: "https://github.com/conchoecia/odp"
+doi: 10.5281/zenodo.7857389
+authors:
+  - family-names: Schultz
+    given-names: "Darrin T."
+    email: darrin.schultz@univie.ac.at
+preferred-citation:
+  type: article
+  title: "Ancient gene linkages support ctenophores as sister to other animals"
+  year: 2023
+  journal: "Nature"
+  volume: 618
+  issue: 7963
+  start: 110
+  end: 117
+  doi: 10.1038/s41586-023-05936-6
+  url: "https://doi.org/10.1038/s41586-023-05936-6"
+  authors:
+    - family-names: Schultz
+      given-names: "Darrin T."
+    - family-names: Haddock
+      given-names: "Steven H. D."
+    - family-names: Bredeson
+      given-names: "Jessen V."
+    - family-names: Green
+      given-names: "Richard E."
+    - family-names: Simakov
+      given-names: Oleg
+    - family-names: Rokhsar
+      given-names: "Daniel S."
+references:
+  - type: article
+    title: "Topological mixing and irreversibility in animal chromosome evolution"
+    year: 2026
+    journal: "Science Advances"
+    volume: 12
+    issue: 34
+    number: "eadz5561"
+    doi: 10.1126/sciadv.adz5561
+    url: "https://doi.org/10.1126/sciadv.adz5561"
+    authors:
+      - family-names: Schultz
+        given-names: "Darrin T."
+      - family-names: Blümel
+        given-names: Arno
+      - family-names: Destanović
+        given-names: Dalila
+      - family-names: Sarigol
+        given-names: Fatih
+      - family-names: Simakov
+        given-names: Oleg

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@ diagrams of conserved linkages between genomes.
       - [ALGs part 7 - Plot mixing of select linkage groups](#plotmixing)
     - [Determine which clade is sister](#4speciesphylogeny)
 - [Citing odp](#cite)
+  - [Parts of odp that need an additional citation](#citesciadv)
 
 ## <a name="uguide"></a>Users' Guide
 
@@ -625,12 +626,39 @@ The output of this program is histograms showing the different measured paramete
 
 ## <a name="cite"></a>Citing odp
 
-If you use `odp` in your work, please cite the following papers:
+If you use `odp` in your work, please cite:
 
 > Schultz, D.T., Haddock, S.H.D., Bredeson, J.V., Green, R.E., Simakov, O & Rokhsar, D.S. (2023)
 > Ancient gene linkages support ctenophores as sister to other animals.
 > *Nature*, **618** (7963):110-117. [https://doi.org/10.1038/s41586-023-05936-6](https://www.nature.com/articles/s41586-023-05936-6)
 
-> Schultz, D.T., Blümel, A., Destanović, D., Sarigol, F., & Simakov, O. (2024).
+That paper describes `odp` itself, and is the correct citation for the great
+majority of the software: the pairwise dot plots, the ribbon diagrams, and the
+ALG-inference workflow (`odp_nway_rbh`, `odp_rbh_to_groupby`,
+`odp_groupby_filter`, `odp_groupby_to_rbh`, `odp_rbh_merge`, `odp_rbh_to_hmm`,
+`odp_rbh_plot_mixing`) and `odp_genome_rearrangement_simulation`.
+
+### <a name="citesciadv"></a>Parts of odp that need an additional citation
+
+Some parts of `odp` were written after the 2023 paper, and were first used and
+described in Schultz et al. (2026). If your work uses any of the entry points
+in the table below, please cite that paper **in addition to** the 2023 paper:
+
+> Schultz, D.T., Blümel, A., Destanović, D., Sarigol, F., & Simakov, O. (2026).
 > Topological mixing and irreversibility in animal chromosome evolution.
-> *bioRxiv*, 2024.07.29.605683. [https://doi.org/10.1101/2024.07.29.605683](https://doi.org/10.1101/2024.07.29.605683)
+> *Science Advances*, **12** (34):eadz5561. [https://doi.org/10.1126/sciadv.adz5561](https://doi.org/10.1126/sciadv.adz5561)
+
+| If you use… | …which lives in |
+|---|---|
+| **`plot_LG_decay: True`** — the ALG decay analysis, which splits the genes of each ALG into those on the orthologous chromosome and those scattered elsewhere, and the `step2-figures/ALG_decay_plots/*_ALG_decay.pdf` and `*_ALG_decay.tsv` files it writes | rule `ALG_decay_plot` in `scripts/odp`, and `plot_decay()` in `source/odp_plotting_functions.py` |
+| **`odp_onlyDB`** — the ALG-database-only mode, which generates each sample's `.rbh` file against an `LG_db` and omits the *n*×*n* species-species comparisons so that thousands of genomes can be processed at once | `scripts/odp_onlyDB` |
+| **`odp_filechecker`** — the standalone input-validation pipeline that was split out of `scripts/odp` so that file checks do not bottleneck large runs | `scripts/odp_filechecker` |
+| **Per-species ALG `.rbh` files** (`plot_LGs: True`) used as the input to an evolutionary genome topology analysis, e.g. in [`egt`](https://github.com/conchoecia/egt) | `scripts/odp`, `scripts/odp_onlyDB` |
+
+The exact `odp` configuration used in Schultz et al. (2026) was
+`ignore_autobreaks: True`, `diamond_or_blastp: diamond`,
+`duplicate_proteins: pass`, `plot_LGs: True`, and `plot_sp_sp: False`,
+comparing the BCnS ALGs (`LG_db/BCnSSimakov2022.tar.gz`) against
+chromosome-scale animal genomes.
+
+See also [`CITATION.cff`](../CITATION.cff).

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,7 +103,6 @@ diagrams of conserved linkages between genomes.
       - [ALGs part 7 - Plot mixing of select linkage groups](#plotmixing)
     - [Determine which clade is sister](#4speciesphylogeny)
 - [Citing odp](#cite)
-  - [Parts of odp that need an additional citation](#citesciadv)
 
 ## <a name="uguide"></a>Users' Guide
 
@@ -632,33 +631,13 @@ If you use `odp` in your work, please cite:
 > Ancient gene linkages support ctenophores as sister to other animals.
 > *Nature*, **618** (7963):110-117. [https://doi.org/10.1038/s41586-023-05936-6](https://www.nature.com/articles/s41586-023-05936-6)
 
-That paper describes `odp` itself, and is the correct citation for the great
-majority of the software: the pairwise dot plots, the ribbon diagrams, and the
-ALG-inference workflow (`odp_nway_rbh`, `odp_rbh_to_groupby`,
-`odp_groupby_filter`, `odp_groupby_to_rbh`, `odp_rbh_merge`, `odp_rbh_to_hmm`,
-`odp_rbh_plot_mixing`) and `odp_genome_rearrangement_simulation`.
-
-### <a name="citesciadv"></a>Parts of odp that need an additional citation
-
-Some parts of `odp` were written after the 2023 paper, and were first used and
-described in Schultz et al. (2026). If your work uses any of the entry points
-in the table below, please cite that paper **in addition to** the 2023 paper:
+Some parts of `odp` came after that paper, and were first described in Schultz
+et al. (2026). Please cite that paper as well if you use the ALG decay analysis
+(`plot_LG_decay`), `odp_onlyDB`, `odp_filechecker`, or the per-species ALG
+`.rbh` files as input to an [`egt`](https://github.com/conchoecia/egt) analysis:
 
 > Schultz, D.T., Blümel, A., Destanović, D., Sarigol, F., & Simakov, O. (2026).
 > Topological mixing and irreversibility in animal chromosome evolution.
 > *Science Advances*, **12** (34):eadz5561. [https://doi.org/10.1126/sciadv.adz5561](https://doi.org/10.1126/sciadv.adz5561)
-
-| If you use… | …which lives in |
-|---|---|
-| **`plot_LG_decay: True`** — the ALG decay analysis, which splits the genes of each ALG into those on the orthologous chromosome and those scattered elsewhere, and the `step2-figures/ALG_decay_plots/*_ALG_decay.pdf` and `*_ALG_decay.tsv` files it writes | rule `ALG_decay_plot` in `scripts/odp`, and `plot_decay()` in `source/odp_plotting_functions.py` |
-| **`odp_onlyDB`** — the ALG-database-only mode, which generates each sample's `.rbh` file against an `LG_db` and omits the *n*×*n* species-species comparisons so that thousands of genomes can be processed at once | `scripts/odp_onlyDB` |
-| **`odp_filechecker`** — the standalone input-validation pipeline that was split out of `scripts/odp` so that file checks do not bottleneck large runs | `scripts/odp_filechecker` |
-| **Per-species ALG `.rbh` files** (`plot_LGs: True`) used as the input to an evolutionary genome topology analysis, e.g. in [`egt`](https://github.com/conchoecia/egt) | `scripts/odp`, `scripts/odp_onlyDB` |
-
-The exact `odp` configuration used in Schultz et al. (2026) was
-`ignore_autobreaks: True`, `diamond_or_blastp: diamond`,
-`duplicate_proteins: pass`, `plot_LGs: True`, and `plot_sp_sp: False`,
-comparing the BCnS ALGs (`LG_db/BCnSSimakov2022.tar.gz`) against
-chromosome-scale animal genomes.
 
 See also [`CITATION.cff`](../CITATION.cff).


### PR DESCRIPTION
`odp` predates this paper, so the 2023 *Nature* paper is still the citation for `odp` itself. This adds a short note to **Citing odp** saying to cite the new paper *as well* when using the parts that came out of it: the ALG decay analysis (`plot_LG_decay`), `odp_onlyDB`, `odp_filechecker`, or the per-species ALG `.rbh` files as input to an [`egt`](https://github.com/conchoecia/egt) analysis. Everything else stays on the 2023 citation alone.

Also adds a `CITATION.cff` with *Nature* as `preferred-citation` and *Science Advances* under `references`.

> Schultz, D.T., Blümel, A., Destanović, D., Sarigol, F., & Simakov, O. (2026). Topological mixing and irreversibility in animal chromosome evolution. *Science Advances*, **12**(34), eadz5561. https://doi.org/10.1126/sciadv.adz5561
